### PR TITLE
Add Credit Support Types in the Agreements schema

### DIFF
--- a/documentation/properties/credit_support_types.md
+++ b/documentation/properties/credit_support_types.md
@@ -1,0 +1,38 @@
+---
+layout:		property
+title:		"credit_support_types"
+schemas:	[agreement]
+---
+
+# credit_support_types
+
+---
+
+**credit\_support\_types** is a means of providing collateral or a security interest for payment obligations under derivative transactions..
+
+### csa_isda_1994
+The [1994 ISDA Credit Support Annex][csa_1994] (Security Interest—New York law), known as the New York law CSA or the New York law annex (the New York law Annex)
+
+It allows parties to establish bilateral mark-to-market security arrangements. This document serves as an Annex to the Schedule to the ISDA Master Agreement and is designed for use in transactions subject to New York law.
+
+
+### csa_isda_1995
+The [1995 ISDA Credit Support Annex][csa_1995] (Transfer—English law), known as the English law CSA or the English law annex (the English law Annex)
+
+It allows parties to establish bilateral mark-to-market arrangements under English law relying on transfer of title to collateral in the form of securities and/or cash and, in the event of default, inclusion of collateral values within the close-out netting provided by Section 6 of the ISDA Master Agreement. The English Credit Support Annex does not create a security interest, but instead relies on netting for its effectiveness. Like the New York Credit Support Annex, it is an Annex to the Schedule to the ISDA Master Agreement.
+
+
+### csd_isda_1995
+The [1995 ISDA Credit Support Deed][csd_1995] (Security interest—English law), known as the English law CSD or the English law deed (the English law Deed)
+
+It allows parties to establish bilateral mark-to-market collateral arrangements under English law relying on the creation of a formal security interest in collateral in the form of securities and/or cash. It is a stand-alone document (not an Annex to the Schedule), but is otherwise comparable to the 1994 ISDA Credit Support Annex for use with ISDA Master Agreements subject to New York law (which also relies on the creation of a formal security interest in the collateral).
+
+### scsa_isda_2013
+The [Standard CSA][scsa] for both the English and New York law Annexes, published in 2013.
+
+The Standard Credit Support Annex (SCSA or Standard CSA) seeks to standardize market practice regarding embedded optionality in current CSAs, promote the adoption of overnight index swap discounting for derivatives, and align the mechanics and economics of collateralization between the bilateral and cleared OTC derivative markets. Additionally, the SCSA seeks to create a homogeneous valuation framework, reducing current barriers to novation and valuation disputes
+
+[csa_1995]: https://www.isda.org/a/JnMDE/1995-ISDA-Credit-Support-Annex-English-Law.pdf
+[csd_1995]: https://www.isda.org/book/1995-isda-credit-support-deed-pdf/
+[csa_1994]: https://www.isda.org/book/1994-isda-credit-support-annex-security-int-ny-law/
+[scsa]: https://www.isda.org/2013/06/07/the-2013-standard-credit-support-annex/

--- a/v1-dev/agreement.json
+++ b/v1-dev/agreement.json
@@ -38,13 +38,20 @@
       ]
     },
     "type": {
-      "description": "The type of agreement.",
+      "description": "The type of the master agreement.",
       "type": "string",
       "enum": [
          "isda", "isda_2002", "isda_1992", "isda_1987", "isda_1986", "isda_1985", "other_isda",
          "gmra", "icma_2011", "icma_2000", "icma_1995", "icma_1992", "other_gmra",
          "other"
       ]
+    },
+    "credit_support_type": {
+        "description": "The type of credit support document",
+        "type": "string",
+        "enum": [
+            "csa_isda_1994", "csa_isda_1995", "csd_isda_1995", "scsa_isda_2013"
+        ]
     },
     "version_id": {
       "description": "The version identifier of the data such as the firm's internal batch identifier.",


### PR DESCRIPTION
Adding Credit Support Types into the Agreements schema. This includes types  "csa_isda_1994", "csa_isda_1995", "csd_isda_1995" and "scsa_isda_2013"