### PR TITLE
addition of 2 account purposes for fees

### DIFF
--- a/documentation/properties/purpose.md
+++ b/documentation/properties/purpose.md
@@ -41,6 +41,8 @@ The **purpose** property describes the reason behind the creation or usage of th
 │   ├── insurance_fee
 │   ├── investment_banking_fee
 │   ├── loan_and_advance_fee
+│   │   ├── mortgage_fee
+│   │   └── unsecured_loan_fee
 │   ├── other_fs_fee
 │   └── other_non_fs_fee
 ├── fines
@@ -206,8 +208,14 @@ Describes an account that holds the amount of fees receivables/payables originat
 ### derivative_fee
 Describes an account that holds the amount of fees receivables/payables originating from **overdraft accounts**.
 
+### mortgage_fee
+Describes an account that holds the amount of fees receivables originating from **mortgage products**.
+
 ### overdraft_fee
 Describes an account that holds the amount of fees receivables originating from **overdraft accounts**.
+
+### unsecured_loan_fee
+Describes an account that holds the amount of fees receivables originating from **unsecured personal loans**.
 
 ### insurance_fee
 Describes an account that holds the amount of fees receivables originating from **insurance** activities.

--- a/v1-dev/account.json
+++ b/v1-dev/account.json
@@ -231,6 +231,7 @@
         "loan_and_advance_fee",
         "ni_contribution",
         "manufactured_dividend",
+        "mortgage_fee",
         "non_life_ins_premium",
         "occupancy_cost",
         "operational",
@@ -264,6 +265,7 @@
         "staff",
         "system",
         "tax",
+        "unsecured_loan_fee",
         "write_off"
       ]
     },


### PR DESCRIPTION
2 new account purposes for BoE statistical reporting to record the following fees:
 - fees on mortgage
 - fees on unsecured personal loans