### PR TITLE
updated Derivative and DerivativeCashFlow schemas for SACCR

### DIFF
--- a/documentation/properties/type.md
+++ b/documentation/properties/type.md
@@ -834,6 +834,7 @@ Any other account type that cannot be classified as one of the other types.
 ├── vanilla_swap
 ├── mtm_swap
 ├── cds
+├── ccds
 ├── ois
 ├── xccy
 ├── nds
@@ -862,6 +863,10 @@ Overnight Index Swap
 
 ### cds
 Credit Default Swap
+
+### ccds
+Contingent Credit Default Swap
+Protection on the mark-to-market of a specifc derivative transaction in case of a credit event affecting the transaction counterparty
 
 ### tarf
 Target Redemption Forward

--- a/v1-dev/derivative.json
+++ b/v1-dev/derivative.json
@@ -262,7 +262,7 @@
       "description": "This is the type of the derivative with regards to common regulatory classifications.",
       "type": "string",
       "enum": [
-        "vanilla_swap", "mtm_swap", "option", "call_swaption", "put_swaption", "call_option", "put_option", "future", "forward", "tarf", "xccy", "cds", "ois", "spot", "ndf", "nds", "fra", "cap", "floor"
+        "vanilla_swap", "mtm_swap", "option", "call_swaption", "put_swaption", "call_option", "put_option", "future", "forward", "tarf", "xccy", "cds", "ois", "spot", "ndf", "nds", "fra", "cap", "floor", "ccds"
       ]
     },
     "trade_date": {
@@ -285,7 +285,7 @@
     "underlying_index_tenor": {
       "description": "The designated maturity of the underlying interest rate index used in the underlying_index property for interest rate derivatives",
       "type": "string",
-      "enum": ["1d", "1m", "2m", "3m", "6m", "12m"]
+      "enum": ["1d", "7d", "1m", "2m", "3m", "4m", "5m", "6m", "7m", "8m", "9m", "12m"]
    },
     "underlying_issuer_id": {
       "description": "The unique identifier used by the financial institution to identify the underlying reference issuer for this derivative.",

--- a/v1-dev/derivative_cash_flow.json
+++ b/v1-dev/derivative_cash_flow.json
@@ -44,6 +44,10 @@
       "description": "Unique identifier to the derivative to which this cash flow relates",
       "type": "string"
     },
+    "forward_rate": {
+      "description": "Rate used to set a variable cash flow on the reset_date",
+      "type": "number",
+    },
     "leg": {
       "description": "The type of the payment leg.",
       "type": "string",
@@ -93,6 +97,11 @@
     "reporting_id": {
       "description": "The internal ID for the legal entity under which the account is being reported.",
       "type": "string"
+    },
+    "reset_date": {
+      "description": "Date on which a variable cash flow amount is set. YYYY-MM-DDTHH:MM:SSZ in accordance with ISO 8601.",
+      "type": "string",
+      "format": "date-time"
     },
     "settlement_type": {
       "description": "The type of settlement for the contract.",

--- a/v1-dev/derivative_cash_flow.json
+++ b/v1-dev/derivative_cash_flow.json
@@ -46,7 +46,7 @@
     },
     "forward_rate": {
       "description": "Rate used to set a variable cash flow on the reset_date",
-      "type": "number",
+      "type": "number"
     },
     "leg": {
       "description": "The type of the payment leg.",


### PR DESCRIPTION
Derivative schema:
- derivative_type: ccds
- underlying_index_tenor: 7d, 4m, 5m, 7m, 8m, 9m

DerivativeCashFlow schema new fields: reset_date, forward_rate