### PR TITLE
Adds annotations to monetary types

### DIFF
--- a/v1-dev/account.json
+++ b/v1-dev/account.json
@@ -15,25 +15,29 @@
     },
     "acc_fv_change_before_taxes": {
       "description": "Accumulated change in fair value before taxes.",
-      "type": "integer"
+      "type": "integer",
+      "monetary": true
     },
     "accounting_treatment":{
        "$ref": "https://raw.githubusercontent.com/SuadeLabs/fire/master/v1-dev/common.json#/accounting_treatment"
     },
     "accrued_interest": {
       "description": "The accrued interest since the last payment date and due at the next payment date. Monetary type represented as a naturally positive integer number of cents/pence.",
-      "type": "integer"
+      "type": "integer",
+      "monetary": true
     },
     "arrears_balance": {
       "description": "The balance of the capital amount that is considered to be in arrears (for overdrafts/credit cards). Monetary type represented as a naturally positive integer number of cents/pence.",
-      "type": "integer"
+      "type": "integer",
+      "monetary": true
     },
     "asset_liability": {
       "$ref": "https://raw.githubusercontent.com/SuadeLabs/fire/master/v1-dev/common.json#/asset_liability"
     },
     "balance": {
       "description": "The contractual balance on the date and in the currency given. Monetary type represented as a naturally positive integer number of cents/pence.",
-      "type": "integer"
+      "type": "integer",
+      "monetary": true
     },
     "base_rate": {
       "description": "The base rate represents the basis of the rate on the balance at the given date as agreed in the terms of the account.",
@@ -86,7 +90,8 @@
     "encumbrance_amount": {
       "description": "The amount of the account that is encumbered by potential future commitments or legal liabilities. Monetary type represented as a naturally positive integer number of cents/pence.",
       "type": "integer",
-      "minimum": 0
+      "minimum": 0,
+      "monetary": true
     },
     "encumbrance_type": {
       "description": "The type of the encumbrance causing the encumbrance_amount.",
@@ -107,7 +112,8 @@
     "guarantee_amount": {
       "description": "The amount of the account that is guaranteed under a Government Deposit Guarantee Scheme. Monetary type represented as a naturally positive integer number of cents/pence.",
       "type": "integer",
-      "minimum": 0
+      "minimum": 0,
+      "monetary": true
     },
     "guarantee_scheme": {
       "description": "The Government Deposit Scheme scheme under which the guarantee_amount is guaranteed.",
@@ -122,13 +128,14 @@
     "impairment_amount": {
       "description": "The impairment amount is the allowance set aside by the firm that accounts for the event that the asset becomes impaired in the future.",
       "type": "integer",
-      "minimum": 0
+      "minimum": 0,
+      "monetary": true
     },
     "impairment_status": {
       "$ref": "https://raw.githubusercontent.com/SuadeLabs/fire/master/v1-dev/common.json#/impairment_status"
     },
     "insolvency_rank": {
-      "description": "The insolvency ranking as per the national legal fraamework of the reporting institution.",
+      "description": "The insolvency ranking as per the national legal framework of the reporting institution.",
       "type": "integer",
       "minimum": 1
     },
@@ -143,7 +150,8 @@
     },
     "limit_amount": {
       "description": "The minimum balance the customer can go overdrawn in their account.",
-      "type": "integer"
+      "type": "integer",
+      "monetary": true
     },
     "next_payment_date": {
       "description": "The next date at which interest will be paid or accrued_interest balance returned to zero.",
@@ -356,7 +364,8 @@
     },
     "withdrawal_penalty": {
       "description": "This is the penalty incurred by the customer for an early withdrawal on this account. An early withdrawal is defined as a withdrawal prior to the next_withdrawal_date. Monetary type represented as a naturally positive integer number of cents/pence.",
-      "type": "integer"
+      "type": "integer",
+      "monetary": true
     },
     "count": {
       "description": "Describes the number of accounts aggregated into a single row.",
@@ -365,7 +374,8 @@
     },
     "minimum_balance_eur": {
       "description": "Indicates the minimum balance, in Euros, of each account within the aggregate. Monetary type represented as a naturally positive integer number of cents/pence.",
-      "type": "integer"
+      "type": "integer",
+      "monetary": true
     },
     "next_repricing_date": {
       "description": "The date on which the interest rate of the account will be re-calculated. YYYY-MM-DDTHH:MM:SSZ in accordance with ISO 8601.",

--- a/v1-dev/adjustment.json
+++ b/v1-dev/adjustment.json
@@ -23,7 +23,8 @@
     },
     "contribution_amount": {
       "description": "The contribution amount this adjustment should make to the specified report cell. A positive/negative number in minor units (cents/pence).",
-      "type": "integer"
+      "type": "integer",
+      "monetary": true
     },
     "contribution_text": {
       "description": "The text to use for the adjustment where the reported cell is not a monetary value.",

--- a/v1-dev/agreement.json
+++ b/v1-dev/agreement.json
@@ -47,7 +47,8 @@
     },
     "minimum_transfer_amount": {
       "description": "Smallest amount of collateral that can be transferred. Monetary type represented as a naturally positive integer number of cents/pence.",
-      "type": "integer"
+      "type": "integer",
+      "monetary": true
     },
     "netting_restriction": {
       "description": "populated only if any netting restriction applies, in relation to the nature of the agreement or the enforceability of netting in the jurisdiction of the counterparty, preventing the recognition of the agreement as risk-reducing, pursuant to CRR Articles 295 to 298",
@@ -76,7 +77,8 @@
     },
     "threshold": {
       "description": "Amount below which collateral is not required. Monetary type represented as a naturally positive integer number of cents/pence.",
-      "type": "integer"
+      "type": "integer",
+      "monetary": true
     },
     "type": {
       "description": "The type of the master agreement.",

--- a/v1-dev/collateral.json
+++ b/v1-dev/collateral.json
@@ -40,7 +40,8 @@
     "encumbrance_amount": {
       "description": "The amount of the collateral that is encumbered by potential future commitments or legal liabilities. Monetary type represented as a naturally positive integer number of cents/pence.",
       "type": "integer",
-      "min": 0
+      "min": 0,
+      "monetary": true
     },
     "encumbrance_type": {
       "description": "The type of the encumbrance causing the encumbrance_amount.",
@@ -71,7 +72,8 @@
     },
     "value": {
       "description": "The valuation as used by the bank for the collateral on the value_date. Monetary type represented as a naturally positive integer number of cents/pence.",
-      "type": "integer"
+      "type": "integer",
+      "monetary": true
     },
     "value_date": {
       "description": "The timestamp that the collateral was valued. YYYY-MM-DDTHH:MM:SSZ in accordance with ISO 8601.",

--- a/v1-dev/customer.json
+++ b/v1-dev/customer.json
@@ -10,7 +10,8 @@
     "annual_debit_turnover": {
       "description": "The annual debit turnover in the business account of the entity. Monetary type represented as a naturally positive integer number of cents/pence.",
       "type": "integer",
-      "minimum": 0
+      "minimum": 0,
+      "monetary": true
     },
     "currency_code": {
       "description": "Currency in accordance with ISO 4217. It should be consistent with annual_debit_turnover and incurred_cva.",
@@ -23,7 +24,8 @@
     },
     "incurred_cva": {
       "description": "The amount of credit valuation adjustements being recognised by the institution as an incurred write-down, calculated without taking into account any offsetting debit value adjustment attributed to the firm's own credit risk, that has been already excluded from own funds.",
-      "type": "integer"
+      "type": "integer",
+      "monetary": true
     },
     "product_count": {
       "description": "The number of active products/trades this customer has with the firm.",

--- a/v1-dev/derivative.json
+++ b/v1-dev/derivative.json
@@ -22,7 +22,8 @@
     },
     "accrued_interest": {
       "description": "The accrued interest since the last payment date and due at the next payment date. Monetary type represented as a naturally positive integer number of cents/pence.",
-      "type": "integer"
+      "type": "integer",
+      "monetary": true
     },
     "asset_class": {
       "$ref": "https://raw.githubusercontent.com/SuadeLabs/fire/master/v1-dev/common.json#/asset_class"
@@ -32,7 +33,8 @@
     },
     "balance": {
       "description": "Outstanding amount including accrued interest. Monetary type represented as a naturally positive integer number of cents/pence.",
-      "type": "integer"
+      "type": "integer",
+      "monetary": true
     },
     "base_rate": {
       "description": "The base rate represents the basis of the rate on the balance at the given date as agreed in the terms of the financial product.",
@@ -100,7 +102,8 @@
     "impairment_amount": {
       "description": "The impairment amount for a security is the allowance set aside by the firm for losses.",
       "type": "integer",
-      "minimum": 0
+      "minimum": 0,
+      "monetary": true
     },
     "impairment_status": {
       "$ref": "https://raw.githubusercontent.com/SuadeLabs/fire/master/v1-dev/common.json#/impairment_status"
@@ -111,7 +114,8 @@
     },
     "initial_margin": {
       "description": "Upfront margin posted/received for the trade. Monetary type as integer number of cents.",
-      "type": "integer"
+      "type": "integer",
+      "monetary": true
     },
     "insolvency_rank": {
       "description": "The insolvency ranking as per the national legal framework of the reporting institution.",
@@ -146,11 +150,13 @@
     },
     "mtm_clean": {
       "description": "The mark-to-market value of the derivative excluding interest. Monetary type represented as a naturally positive integer number of cents/pence.",
-      "type": "integer"
+      "type": "integer",
+      "monetary": true
     },
     "mtm_dirty": {
       "description": "The mark-to-market value of the derivative including interest. Monetary type represented as a naturally positive integer number of cents/pence.",
-      "type": "integer"
+      "type": "integer",
+      "monetary": true
     },
     "next_exercise_date": {
       "description": "The next date at which the option can be exercised.",
@@ -159,7 +165,8 @@
     },
     "next_payment_amount": {
       "description": "The amount that will need to be paid at the next_payment_date. Monetary type represented as a naturally positive integer number of cents/pence.",
-      "type": "integer"
+      "type": "integer",
+      "monetary": true
     },
     "next_payment_date": {
       "description": "The next date at which interest will be paid or accrued_interest balance returned to zero.",
@@ -168,7 +175,8 @@
     },
     "next_receive_amount": {
       "description": "The amount that is expected to be received at the next_receive_date. Monetary type represented as a naturally positive integer number of cents/pence.",
-      "type": "integer"
+      "type": "integer",
+      "monetary": true
     },
     "next_receive_date": {
       "description": "The next date at which interest will be received or accrued_interest balance returned to zero.",
@@ -182,7 +190,8 @@
     },
     "notional_amount": {
       "description": "The notional value is the total value with regard to a derivative's underlying index, security or asset at its spot price in accordance with the specifications (i.e. leverage) of the derivative product. Monetary type represented as a naturally positive integer number of cents/pence.",
-      "type": "integer"
+      "type": "integer",
+      "monetary": true
     },
     "on_balance_sheet": {
       "description": "Is the derivative reported on the balance sheet of the financial institution?",

--- a/v1-dev/derivative_cash_flow.json
+++ b/v1-dev/derivative_cash_flow.json
@@ -15,7 +15,8 @@
     },
     "accrued_interest": {
       "description": "The accrued interest/premium due at the next payment date. Monetary type represented as a naturally positive integer number of cents/pence.",
-      "type": "integer"
+      "type": "integer",
+      "monetary": true
     },
     "asset_class": {
       "$ref": "https://raw.githubusercontent.com/SuadeLabs/fire/master/v1-dev/common.json#/asset_class"
@@ -26,7 +27,8 @@
     },
     "balance": {
       "description": "The contractual balance due on the payment date in the currency given. Monetary type represented as a naturally positive integer number of cents/pence.",
-      "type": "integer"
+      "type": "integer",
+      "monetary": true
     },
     "csa_id": {
       "description": "The unique identifier of the credit support annex for this derivative cash flow",
@@ -59,15 +61,18 @@
     },
     "mtm_clean": {
       "description": "The mark-to-market value of the derivative cash flow excluding interest/premium/coupons. Monetary type represented as a naturally positive integer number of cents/pence.",
-      "type": "integer"
+      "type": "integer",
+      "monetary": true
     },
     "mtm_dirty": {
       "description": "The mark-to-market value of the derivative cash flow including interest/premium/coupons. Monetary type represented as a naturally positive integer number of cents/pence.",
-      "type": "integer"
+      "type": "integer",
+      "monetary": true
     },
     "notional_amount": {
       "description": "The notional value is the total value with regard to a derivative's underlying index, security or asset at its spot price in accordance with the specifications (i.e. leverage) of the derivative product. Monetary type represented as a naturally positive integer number of cents/pence.",
-      "type": "integer"
+      "type": "integer",
+      "monetary": true
     },
     "on_balance_sheet": {
       "description": "Is the financial product reported on the balance sheet of the financial institution?",

--- a/v1-dev/loan.json
+++ b/v1-dev/loan.json
@@ -15,18 +15,21 @@
     },
     "acc_fv_change_before_taxes": {
       "description": "Accumulated change in fair value before taxes.",
-      "type": "integer"
+      "type": "integer",
+      "monetary": true
     },
     "acc_fv_change_credit_risk": {
       "description": "Accumulated changes in fair value due to credit risk.",
-      "type": "integer"
+      "type": "integer",
+      "monetary": true
     },
     "accounting_treatment":{
        "$ref": "https://raw.githubusercontent.com/SuadeLabs/fire/master/v1-dev/common.json#/accounting_treatment"
     },
     "accrued_interest_balance": {
       "description": "The accrued interest due at the next payment date. Monetary type represented as a naturally positive integer number of cents/pence.",
-      "type": "integer"
+      "type": "integer",
+      "monetary": true
     },
     "administration": {
       "description": "How the loan was administered by the lender.",
@@ -40,14 +43,16 @@
     },
     "arrears_balance": {
       "description": "The balance of the loan or capital amount that is considered to be in arrears. Monetary type represented as a naturally positive integer number of cents/pence.",
-      "type": "integer"
+      "type": "integer",
+      "monetary": true
     },
     "asset_liability": {
         "$ref": "https://raw.githubusercontent.com/SuadeLabs/fire/master/v1-dev/common.json#/asset_liability"
     },
     "balance": {
       "description": "The balance of the loan or capital still to be repaid. Monetary type represented as a naturally positive integer number of cents/pence.",
-      "type": "integer"
+      "type": "integer",
+      "monetary": true
     },
     "base_rate": {
       "description": "The base rate represents the basis of the repayment rate on the borrowed funds at the given date as agreed in the terms of the loan.",
@@ -69,7 +74,8 @@
     "cum_recoveries": {
       "description": "The total amount recovered since the date of default of the instrument.",
       "type": "integer",
-      "minimum": 0
+      "minimum": 0,
+      "monetary": true
     },
     "currency_code": {
       "$ref": "https://raw.githubusercontent.com/SuadeLabs/fire/master/v1-dev/common.json#/currency_code"
@@ -93,7 +99,8 @@
           "income_amount": {
             "description": "The reference income used for the customer(s) for this loan. Monetary type represented as an integer number of cents/pence.",
             "type": "integer",
-            "minimum": 0
+            "minimum": 0,
+            "monetary": true
           }
         },
         "required": ["id", "income_amount"]
@@ -107,7 +114,8 @@
     "encumbrance_amount": {
       "description": "The amount of the loan that is encumbered by potential future commitments or legal liabilities. Monetary type represented as a naturally positive integer number of cents/pence.",
       "type": "integer",
-      "minimum": 0
+      "minimum": 0,
+      "monetary": true
     },
     "encumbrance_end_date": {
       "description": "Date encumbrance amount goes to zero. YYYY-MM-DDTHH:MM:SSZ in accordance with ISO 8601",
@@ -142,7 +150,8 @@
     "guarantee_amount": {
       "description": "The amount of the loan that is guaranteed by the guarantor. Monetary type represented as a naturally positive integer number of cents/pence.",
       "type": "integer",
-      "minimum": 0
+      "minimum": 0,
+      "monetary": true
     },
     "guarantor_id": {
       "description": "The unique identifier for the guarantor of the loan.",
@@ -151,7 +160,8 @@
     "impairment_amount": {
       "description": "The impairment amount for a loan is the allowance for loan impairments set aside by the firm that accounts for the event that the loan becomes impaired in the future.",
       "type": "integer",
-      "minimum": 0
+      "minimum": 0,
+      "monetary": true
     },
     "impairment_status": {
       "$ref": "https://raw.githubusercontent.com/SuadeLabs/fire/master/v1-dev/common.json#/impairment_status"
@@ -183,12 +193,14 @@
     "limit_amount": {
       "description": "The total credit limit on the loan. Monetary type represented as a naturally positive integer number of cents/pence.",
       "type": "integer",
-      "minimum": 0
+      "minimum": 0,
+      "monetary": true
     },
     "lnrf_amount": {
       "description": "The total amount of non-recourse funding linked to the loan. Monetary type represented as a naturally positive integer number of cents/pence.",
       "type": "integer",
-      "minimum": 0
+      "minimum": 0,
+      "monetary": true
     },
     "movement": {
       "description": "The movement parameter describes how the loan arrived to the firm.",
@@ -202,7 +214,8 @@
     },
     "notional_amount": {
       "description": "The original notional amount of the loan. Monetary type represented as a naturally positive integer number of cents/pence.",
-      "type": "integer"
+      "type": "integer",
+      "monetary": true
     },
     "on_balance_sheet": {
       "description": "Is the loan reported on the balance sheet of the financial institution?",
@@ -229,7 +242,8 @@
     "provision_amount": {
       "description": "The amount of reserves that is provisioned by the financial institution to cover the potential loss on the loan. Monetary type represented as a naturally positive integer number of cents/pence.",
       "type": "integer",
-      "minimum": 0
+      "minimum": 0,
+      "monetary": true
     },
     "provision_type": {
       "description": "The provision type parameter details the provisions the issuing firm has allocated to cover potential losses from issuing a loan.",
@@ -256,7 +270,8 @@
     "ref_income_amount": {
       "description": "The reference income used for the customer(s) for this loan. Monetary type represented as an integer number of cents/pence.",
       "type": "integer",
-      "minimum": 0
+      "minimum": 0,
+      "monetary": true
     },
     "regulated": {
       "description": "Is this loan regulated or unregulated?",
@@ -340,7 +355,8 @@
     },
     "minimum_balance_eur": {
       "description": "Indicates the minimum balance, in Euros, of each loan within the aggregate.",
-      "type": "integer"
+      "type": "integer",
+      "monetary": true
     },
     "next_repricing_date": {
       "description": "The date on which the interest rate of the loan will be re-calculated. YYYY-MM-DDTHH:MM:SSZ in accordance with ISO 8601.",

--- a/v1-dev/loan_transaction.json
+++ b/v1-dev/loan_transaction.json
@@ -15,7 +15,8 @@
     },
     "amount": {
       "description": "The size of the transaction in the loan transaction event. Monetary type represented as a naturally positive integer number of cents/pence.",
-      "type": "integer"
+      "type": "integer",
+      "monetary": true
     },
     "currency_code": {
       "$ref": "https://raw.githubusercontent.com/SuadeLabs/fire/master/v1-dev/common.json#/currency_code"

--- a/v1-dev/security.json
+++ b/v1-dev/security.json
@@ -16,18 +16,21 @@
     },
     "acc_fv_change_before_taxes": {
       "description": "Accumulated change in fair value before taxes.",
-      "type": "integer"
+      "type": "integer",
+      "monetary": true
     },
     "acc_fv_change_credit_risk": {
       "description": "Accumulated changes in fair value due to credit risk.",
-      "type": "integer"
+      "type": "integer",
+      "monetary": true
     },
     "accounting_treatment":{
        "$ref": "https://raw.githubusercontent.com/SuadeLabs/fire/master/v1-dev/common.json#/accounting_treatment"
     },
     "accrued_interest": {
       "description": "The accrued interest since the last payment date and due at the next payment date. Monetary type represented as an integer number of cents/pence.",
-      "type": "integer"
+      "type": "integer",
+      "monetary": true
     },
     "asset_liability": {
         "description": "Is the security (valued at either amortised cost or fair value) an asset or a liability on the firm's balance sheet.",
@@ -50,7 +53,8 @@
     },
     "balance": {
       "description": "Outstanding amount including accrued interest. Monetary integer number of cents/pence.",
-      "type": "integer"
+      "type": "integer",
+      "monetary": true
     },
     "base_rate": {
       "description": "The base rate represents the basis of the rate on the balance at the given date as agreed in the terms of the financial product.",
@@ -110,7 +114,8 @@
     "encumbrance_amount": {
       "description": "The amount of the security that is encumbered by potential future commitments or legal liabilities such as within a repo pool. Monetary type represented as a naturally positive integer number of cents/pence.",
       "type": "integer",
-      "minimum": 0
+      "minimum": 0,
+      "monetary": true
     },
     "end_date": {
       "description": "YYYY-MM-DDTHH:MM:SSZ in accordance with ISO 8601",
@@ -145,7 +150,8 @@
     "impairment_amount": {
       "description": "The impairment amount for a security is the allowance set aside by the firm for losses.",
       "type": "integer",
-      "minimum": 0
+      "minimum": 0,
+      "monetary": true
     },
     "impairment_status": {
       "$ref": "https://raw.githubusercontent.com/SuadeLabs/fire/master/v1-dev/common.json#/impairment_status"
@@ -210,11 +216,13 @@
     },
     "mtm_clean": {
       "description": "The mark-to-market value of the security excluding interest. Monetary number of cents/pence.",
-      "type": "integer"
+      "type": "integer",
+      "monetary": true
     },
     "mtm_dirty": {
       "description": "The mark-to-market value of the security including interest. Monetary number of cents/pence.",
-      "type": "integer"
+      "type": "integer",
+      "monetary": true
     },
     "next_payment_date": {
       "description": "The next date at which interest will be paid or accrued_interest balance returned to zero.",
@@ -223,7 +231,8 @@
     },
     "notional_amount": {
       "description": "The notional value is the total amount of a security's underlying asset at its spot price. Monetary number of cents.",
-      "type": "integer"
+      "type": "integer",
+      "monetary": true
     },
     "on_balance_sheet": {
       "description": "Is the security reported on the balance sheet of the financial institution?",


### PR DESCRIPTION
This will allow us to automatically distinguish between true integers and those which represent monetary values. Useful for e.g. ascertaining which fields exchange rates apply to.