### PR TITLE
Add ccf to accounts (for overdrafts)

### DIFF
--- a/v1-dev/account.json
+++ b/v1-dev/account.json
@@ -82,6 +82,9 @@
       "description": "The unique identifier used by the financial institution to identify the customer that owns the account.",
       "type": "string"
     },
+    "ccf": {
+      "$ref": "https://raw.githubusercontent.com/SuadeLabs/fire/master/v1-dev/common.json#/ccf"
+    },
     "end_date": {
       "description": "The end or maturity date of the account. Format should be YYYY-MM-DDTHH:MM:SSZ in accordance with ISO 8601",
       "type": "string",

--- a/v1-dev/common.json
+++ b/v1-dev/common.json
@@ -138,5 +138,10 @@
   "type": "string",
   "minLength": 4,
   "maxLength": 4
+ },
+ "ccf": {
+  "description": "The credit conversion factor that indicates the proportion of the undrawn amount that would be drawn down on default.",
+  "type": "number",
+  "minimum": 0
  }
 }

--- a/v1-dev/loan.json
+++ b/v1-dev/loan.json
@@ -107,9 +107,7 @@
       }
     },
     "ccf": {
-      "description": "The credit conversion factor that indicates the proportion of the undrawn amount that would be drawn down on default.",
-      "type": "number",
-      "minimum": 0
+      "$ref": "https://raw.githubusercontent.com/SuadeLabs/fire/master/v1-dev/common.json#/ccf"
     },
     "encumbrance_amount": {
       "description": "The amount of the loan that is encumbered by potential future commitments or legal liabilities. Monetary type represented as a naturally positive integer number of cents/pence.",


### PR DESCRIPTION
This update covers the case of overdraft accounts, which will need a ccf for the C07