### PR TITLE
Add single_income field for loans

### DIFF
--- a/documentation/properties/income_assessment.md
+++ b/documentation/properties/income_assessment.md
@@ -1,19 +1,27 @@
 ---
 layout:		property
-title:		"single_income"
+title:		"income_assessment"
 schemas:	[loan]
 ---
 
-# single_income
+# income_assessment
 
 ---
 
 Parameter to determine whether a single or joint income was used when assessing the loan.
 
-
+### single
 The [FCA][fca] defines single and joint income loans as follows:
 
 > Single income basis. This means only one person's income was taken into account when making the lending assessment/decision.
 > Joint income basis. This means that two or more persons' incomes were used in the lending assessment/decision.
 
+### joint
+(see above)
+
+More on income assessment can be found in the [FCA Handbook section on Responsible Lending][responsible-lending]
+
+
+---
 [fca]: https://www.handbook.fca.org.uk/handbook/SUP/16/Annex19B.html
+[responsible-lending]: https://www.handbook.fca.org.uk/handbook/MCOB/11/6.html

--- a/documentation/properties/single_income.md
+++ b/documentation/properties/single_income.md
@@ -13,7 +13,7 @@ Parameter to determine whether a single or joint income was used when assessing 
 
 The [FCA][fca] defines single and joint income loans as follows:
 
-> Single income basis. This means only one person's income was taken into account when making the lending assess> ment/decision.
+> Single income basis. This means only one person's income was taken into account when making the lending assessment/decision.
 > Joint income basis. This means that two or more persons' incomes were used in the lending assessment/decision.
 
 [fca]: https://www.handbook.fca.org.uk/handbook/SUP/16/Annex19B.html

--- a/documentation/properties/single_income.md
+++ b/documentation/properties/single_income.md
@@ -1,0 +1,19 @@
+---
+layout:		property
+title:		"single_income"
+schemas:	[loan]
+---
+
+# secured
+
+---
+
+Parameter to determine whether a single or joint income was used when assessing the loan.
+
+
+The [FCA][fca] defines single and joint income loans as follows:
+
+> Single income basis. This means only one person's income was taken into account when making the lending assess> ment/decision.
+> Joint income basis. This means that two or more persons' incomes were used in the lending assessment/decision.
+
+[fca]: https://www.handbook.fca.org.uk/handbook/SUP/16/Annex19B.html

--- a/documentation/properties/single_income.md
+++ b/documentation/properties/single_income.md
@@ -4,7 +4,7 @@ title:		"single_income"
 schemas:	[loan]
 ---
 
-# secured
+# single_income
 
 ---
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -6,10 +6,6 @@ echo "===> Flake8 Running..."
 flake8 . --exclude "*venv*"
 echo "===> Flake8 Finished"
 
-echo "===> Python2 Tests Running..."
-python2 -m pytest -v
-echo "===> Python2 Tests Finished"
-
 echo "===> Python3 Tests Running..."
 python3 -m pytest -v
 echo "===> Python3 Tests Finished"

--- a/v1-dev/loan.json
+++ b/v1-dev/loan.json
@@ -182,6 +182,11 @@
       "type": "string",
       "enum": ["collective", "individual", "write_off"]
     },
+    "income_assessment": {
+      "description": "Was the loan assessed against a single or joint incomes?",
+      "type": "string",
+      "enum": ["joint", "single"]
+    },
     "interest_repayment_frequency": {
       "description": "Repayment frequency of the loan interest, if different from principal.",
       "type": "string",
@@ -361,10 +366,6 @@
     },
     "secured": {
       "description": "Is this loan secured or unsecured?",
-      "type": "boolean"
-    },
-    "single_income": {
-      "description": "Was the loan assessed against a single person's income?",
       "type": "boolean"
     },
     "source": {

--- a/v1-dev/loan.json
+++ b/v1-dev/loan.json
@@ -363,6 +363,10 @@
       "description": "Is this loan secured or unsecured?",
       "type": "boolean"
     },
+    "single_income": {
+      "description": "Was the loan assessed against a single person's income?",
+      "type": "boolean"
+    },
     "source": {
       "description": "The source(s) where this data originated. If more than one source needs to be stored for data lineage, it should be separated by a dash. eg. Source1-Source2",
       "type": "string"


### PR DESCRIPTION
As discussed a while back, this will prevent the need for multiple loan customers and along with "ref_income_amount", allow more consistent definitions vs liquidity.