### PR TITLE
Make loan_id a required field for loan_transaction

### DIFF
--- a/v1-dev/loan_transaction.json
+++ b/v1-dev/loan_transaction.json
@@ -56,6 +56,6 @@
       "type": "string"
     }
   },
-  "required": ["id", "date", "amount"],
+  "required": ["id", "date", "amount", "loan_id"],
   "additionalProperties": true
 }


### PR DESCRIPTION
There is no foreseeable case where a loan transaction should exist without a corresponding loan.