### PR TITLE
Add new security type for PIBS

### DIFF
--- a/documentation/properties/type.md
+++ b/documentation/properties/type.md
@@ -516,6 +516,7 @@ Other refers to a type of security not covered by the above. If you find yoursel
 │   ├── spv_other
 │   ├── mtn
 │   │   └── emtn
+│   ├── pibs
 │   └── abs
 │       ├── abs_auto
 │       ├── abs_sme
@@ -618,6 +619,9 @@ An asset-backed security is a security whose income payments and hence value are
 
 ### mtn
 *Needs definition*
+
+### pibs
+Permanent interest bearing shares, or PIBS, are fixed-interest securities issued by building societies. They are bond like instruments in that they pay interest, but they have no maturity date - PIBS typically exist as long as their issuer does.
 
 ### performance_bond
 *Needs definition*

--- a/documentation/properties/type.md
+++ b/documentation/properties/type.md
@@ -621,7 +621,7 @@ An asset-backed security is a security whose income payments and hence value are
 *Needs definition*
 
 ### pibs
-Permanent interest bearing shares, or PIBS, are fixed-interest securities issued by building societies. They are bond like instruments in that they pay interest, but they have no maturity date - PIBS typically exist as long as their issuer does.
+[Building Societies Association](https://www.bsa.org.uk/information/consumer-factsheets/general/what-are-pibs) defines Permanent interest bearing shares (PIBS) as fixed-interest securities issued by building societies, and quoted on the stock market.  They are bond like instruments in that they pay interest, but they have no maturity date - PIBS typically exist as long as their issuer does.
 
 ### performance_bond
 *Needs definition*

--- a/v1-dev/security.json
+++ b/v1-dev/security.json
@@ -486,6 +486,7 @@
         "performance_bond",
         "performance_guarantee",
         "performance_sloc",
+        "pibs",
         "pref_share",
         "rmbs",
         "rmbs_trans",


### PR DESCRIPTION
Adding new security type for permanent interest bearing shares (PIBS), this is to allow us to differentiate between PIBS vs unsecured bonds issued.