### PR TITLE
Change type=ocir to purpose=ocir

### DIFF
--- a/documentation/properties/purpose.md
+++ b/documentation/properties/purpose.md
@@ -691,7 +691,7 @@ The **other** enum value can be used when none of the other enum values apply or
 │    ├──  derivative_collateral
 │    ├──  independent_collateral_amount
 │    ├──  custody
-│    ├──  default_fund 
+│    ├──  default_fund
 │    └──  single_collateral_pool
 ├── reference
 ├── share_capital
@@ -703,6 +703,7 @@ The **other** enum value can be used when none of the other enum values apply or
 ├── aircraft_finance
 ├── insurance
 ├── back_to_back
+├── ocir
 └── other
 ```
 ### investment_advice
@@ -750,6 +751,13 @@ Use this enumeration value to highlight back to back trades defined as "exactly 
 Use this enumeration value to identify to securities which are placed into a central bank single collateral pool. A list of eligible security types for the Bank of England SCP can be found [here][scp]
 
 [scp]: https://www.bankofengland.co.uk/markets/eligible-collateral
+
+### ocir
+Use this enum to refer to funds reserved for the purpose of implementing, from an operational point of view, the resolution strategy and, consequently, to stabilise and restructure the bank.
+
+[Bank of England OCIR][ocir]
+
+[ocir]: https://www.bankofengland.co.uk/-/media/boe/files/prudential-regulation/supervisory-statement/2021/ss421-may-2021.pdf
 
 ---
 

--- a/documentation/properties/type.md
+++ b/documentation/properties/type.md
@@ -541,7 +541,6 @@ Other refers to a type of security not covered by the above. If you find yoursel
 ├── cash_ratio_deposit
 ├── cash
 ├── index
-├── ocir
 └── other
 ```
 
@@ -704,12 +703,6 @@ Performance standby letter of credit
 ### warranty
 *Needs definition*
 
-### ocir
-Use this enum to refer to funds reserved for the purpose of implementing, from an operational point of view, the resolution strategy and, consequently, to stabilise and restructure the bank.
-
-[Bank of England OCIR][ocir]
-
-[ocir]: https://www.bankofengland.co.uk/-/media/boe/files/prudential-regulation/supervisory-statement/2021/ss421-may-2021.pdf
 ### other
 Other refers to a type of security not covered by the above. If you find yourself using this often, please [contribute][contributing].
 

--- a/v1-dev/security.json
+++ b/v1-dev/security.json
@@ -355,7 +355,8 @@
         "reference",
         "share_capital",
         "single_collateral_pool",
-	"trade_finance"
+        "ocir",
+	      "trade_finance"
       ]
     },
     "rate": {
@@ -483,8 +484,7 @@
         "letter_of_credit",
         "mbs",
         "mtn",
-        "ocir",
-	"other",
+	      "other",
         "performance_bond",
         "performance_guarantee",
         "performance_sloc",

--- a/v1-dev/security.json
+++ b/v1-dev/security.json
@@ -356,7 +356,7 @@
         "share_capital",
         "single_collateral_pool",
         "ocir",
-	      "trade_finance"
+        "trade_finance"
       ]
     },
     "rate": {
@@ -484,7 +484,7 @@
         "letter_of_credit",
         "mbs",
         "mtn",
-	      "other",
+        "other",
         "performance_bond",
         "performance_guarantee",
         "performance_sloc",


### PR DESCRIPTION
It makes more sense to make OCIR a purpose rather than a type. 
This way, we can still keep track the underlying product type reserved for resolution event.