### PR TITLE
Add black check to ci pipeline and blacken python files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,11 @@ python:
   - "3.8"
 
 install:
+  - pip install black
   - pip install ruff
   - pip install -r requirements.txt
 
 script:
+  - black . --check
   - ruff .
   - pytest -v

--- a/random_fire_generator.py
+++ b/random_fire_generator.py
@@ -18,7 +18,7 @@ fire_schemas = [
     "v1-dev/issuer.json",
     "v1-dev/loan.json",
     "v1-dev/loan_transaction.json",
-    "v1-dev/security.json"
+    "v1-dev/security.json",
 ]
 WRITE_PATH = ""
 fake = Faker()
@@ -43,7 +43,7 @@ def random_accounting_treatment():
         "loans_and_recs",
         "held_to_maturity",
         "amortised_cost",
-        "fv_oci"
+        "fv_oci",
     ]
     return random.choice(accounting_treatments)
 
@@ -66,7 +66,7 @@ def random_text(n):
 
 def random_date():
     d = fake.date_time_between(start_date="-10y", end_date="+30y")
-    return d.strftime('%Y-%m-%dT%H:%M:%SZ')
+    return d.strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 def insert(product, attr, attr_value):
@@ -117,8 +117,7 @@ def include_embedded_schema_properties(schema):
             f = open("v1-dev/" + inherited_schema, "r")
             inherited_schema = json.load(f)
             schema["properties"] = dict(
-                schema["properties"].items() +
-                inherited_schema["properties"].items()
+                schema["properties"].items() + inherited_schema["properties"].items()
             )
 
     except KeyError:
@@ -128,11 +127,11 @@ def include_embedded_schema_properties(schema):
 
 
 def generate_product_fire(schema, data_type, n):
-    now = datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')
+    now = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
     batch = {
         "name": "Random_FIRE_{}s".format(schema["title"][:-7]),
         "date": now,
-        "data": []
+        "data": [],
     }
 
     schema = include_embedded_schema_properties(schema)
@@ -240,14 +239,12 @@ def generate_product_fire(schema, data_type, n):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(
-        description="Generate random FIRE data points."
-    )
+    parser = argparse.ArgumentParser(description="Generate random FIRE data points.")
     parser.add_argument(
         "count",
         type=int,
         help="Integer number of FIRE data points to generate \
-              for each data type"
+              for each data type",
     )
     args = parser.parse_args()
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,7 +3,7 @@ import os
 
 
 HOME = os.path.join(os.path.dirname(__file__), "..")
-SCHEMAS_DIR = os.path.join(HOME, 'v1-dev')
+SCHEMAS_DIR = os.path.join(HOME, "v1-dev")
 DOCS_DIR = os.path.join(HOME, "documentation", "properties")
 EXAMPLES_DIR = os.path.join(HOME, "examples")
 
@@ -100,11 +100,11 @@ def fire_stats():
 
     N = 1
     for p in combos:
-        N = N*p
+        N = N * p
 
     return {
         "schemas": schemas,
         "properties": properties,
         "unique_properties": len(uniq_properties),
-        "data_combinations": "%e" % N
+        "data_combinations": "%e" % N,
     }

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -6,12 +6,11 @@ from . import (
     DOCS_DIR,
     DOC_NAMES,
     property_doc_name,
-    schema_enum_registry
+    schema_enum_registry,
 )
 
 
 class TestDocs(unittest.TestCase):
-
     def test_property_has_docs(self):
         """
         Ensure there are docs for every new attribute
@@ -74,7 +73,7 @@ class TestDocs(unittest.TestCase):
             "values",
             "vega",
             "vol_adj",
-            "vol_adj_fx"
+            "vol_adj_fx",
         ]
 
         properties = all_properties()
@@ -86,13 +85,11 @@ class TestDocs(unittest.TestCase):
                 no_docs.append(p)
 
         self.assertFalse(
-            no_docs,
-            "No documenation found for properties: {}".format(no_docs)
+            no_docs, "No documenation found for properties: {}".format(no_docs)
         )
         for doc in DOC_NAMES:
             self.assertTrue(
-                doc in properties,
-                "No property found for documenation: {}".format(doc)
+                doc in properties, "No property found for documenation: {}".format(doc)
             )
 
     def test_enums_documented(self):
@@ -102,6 +99,7 @@ class TestDocs(unittest.TestCase):
 
         eg. ### enum_value
         """
+
         def error_msg(schema_name, value, enum):
             return (
                 "Could not find a level-3 header (###) entry for "
@@ -123,10 +121,14 @@ class TestDocs(unittest.TestCase):
                 property_docs = property_doc_name(enum)
 
                 if not property_docs:
-                    raise FileNotFoundError(f"Could not find documentation for: {schema_name} :: {enum}")  # noqa
+                    raise FileNotFoundError(
+                        f"Could not find documentation for: {schema_name} :: {enum}"
+                    )  # noqa
 
                 _file = os.path.join(DOCS_DIR, property_docs)
 
                 for v in values:
                     with open(_file) as enum_doc:
-                        assert "### {}".format(v) in enum_doc.read(), error_msg(schema_name, v, enum)  # noqa
+                        assert "### {}".format(v) in enum_doc.read(), error_msg(
+                            schema_name, v, enum
+                        )  # noqa

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -14,12 +14,11 @@ from . import (
     SCHEMA_FILES,
     SCHEMA_NAMES,
     schema_enum_registry,
-    fire_stats
+    fire_stats,
 )
 
 
 class TestSchemas(unittest.TestCase):
-
     def test_schemas_and_docs_found(self):
         assert SCHEMA_NAMES
         assert DOC_NAMES
@@ -41,7 +40,7 @@ class TestSchemas(unittest.TestCase):
                 "example.json",
                 "guarantor.json",
                 "issuer.json",
-                "reporter.json"
+                "reporter.json",
             ]:
                 assert not enums
             else:
@@ -52,13 +51,14 @@ class TestSchemas(unittest.TestCase):
         Enums should be snake_case (mostly)
         Enums should be less than 24 characters
         """
+
         def snake_error(schema, enum, value):
-            return "{} > {} > {} isn't snake_case!".format(
-                schema, enum, value)
+            return "{} > {} > {} isn't snake_case!".format(schema, enum, value)
 
         def len_error(schema, enum, value, length):
             return "{} > {} > {} longer than 22 chars! ({})".format(
-                schema, enum, value, length)
+                schema, enum, value, length
+            )
 
         exceptions = [
             "country_code",  # ISO 3166
@@ -67,7 +67,7 @@ class TestSchemas(unittest.TestCase):
             "quote_currency_code",  # ISO 4217
             "underlying_index_tenor",  # day convention
             "base_rate",  # Bloomberg tickers,
-            "nace_code"  # Nace code format: A.01.10
+            "nace_code",  # Nace code format: A.01.10
         ]
         legacy_long_names = [
             "independent_collateral_amount",
@@ -89,7 +89,9 @@ class TestSchemas(unittest.TestCase):
                 assert len(enum) == match.end(), snake_error(schema, enum, "")
 
                 if enum not in legacy_long_names:
-                    assert len(enum) <= 22, len_error(schema, enum, "", len(enum))  # noqa: E501
+                    assert len(enum) <= 22, len_error(
+                        schema, enum, "", len(enum)
+                    )  # noqa: E501
 
                 if enum in exceptions:
                     continue
@@ -141,7 +143,7 @@ class TestSchemas(unittest.TestCase):
             "snp_lt",
             "snp_st",
             "fitch_st",
-            "fitch_lt"
+            "fitch_lt",
         ]
         for schema_name in SCHEMA_FILES:
             enums = schema_enum_registry(schema_name)
@@ -198,27 +200,18 @@ class TestExamples:
 
         Feel free to add more.
         """
-        no_data = {
-            "title": "check",
-            "comment": "check"
-        }
+        no_data = {"title": "check", "comment": "check"}
         with pytest.raises(ValidationError):
             self.validator.validate(no_data)
 
-        empty_data = {
-            "title": "check",
-            "comment": "check",
-            "data": {}
-        }
+        empty_data = {"title": "check", "comment": "check", "data": {}}
         with pytest.raises(ValidationError):
             self.validator.validate(empty_data)
 
         no_title = {
             "description": "check",
             "comment": "check",
-            "data": {
-                "account": [{"id": "123", "date": "2020-02-02"}]
-            }
+            "data": {"account": [{"id": "123", "date": "2020-02-02"}]},
         }
         with pytest.raises(ValidationError):
             self.validator.validate(no_title)
@@ -226,9 +219,7 @@ class TestExamples:
         bad_data_type = {
             "title": "check",
             "comment": "check",
-            "data": {
-                "blah": [{"id": "123", "date": "2020-02-02"}]
-            }
+            "data": {"blah": [{"id": "123", "date": "2020-02-02"}]},
         }
         with pytest.raises(ValidationError):
             self.validator.validate(bad_data_type)
@@ -236,9 +227,7 @@ class TestExamples:
         bad_nested_data = {
             "title": "check",
             "comment": "check",
-            "data": {
-                "account": [{"id": 123, "date": "2020-02-02"}]
-            }
+            "data": {"account": [{"id": 123, "date": "2020-02-02"}]},
         }
         with pytest.raises(ValidationError):
             self.validator.validate(bad_nested_data)
@@ -247,10 +236,8 @@ class TestExamples:
             "title": "check",
             "comment": "check",
             "data": {
-                "account": [
-                    {"id": "123", "date": "2020-02-02", "type": "coorent"}
-                ]
-            }
+                "account": [{"id": "123", "date": "2020-02-02", "type": "coorent"}]
+            },
         }
         with pytest.raises(ValidationError):
             self.validator.validate(bad_nested_enum_value)
@@ -258,9 +245,7 @@ class TestExamples:
         nested_null_value = {
             "title": "check",
             "comment": "check",
-            "data": {
-                "account": [{"id": "123", "date": "2020-02-02", "type": None}]
-            }
+            "data": {"account": [{"id": "123", "date": "2020-02-02", "type": None}]},
         }
         with pytest.raises(ValidationError):
             self.validator.validate(nested_null_value)
@@ -271,19 +256,13 @@ class TestExamples:
             "data": {
                 "account": [
                     {"id": "123", "date": "2020-02-02", "type": "current"},
-                    {"id": "123", "date": "2020-02-02", "type": None}
+                    {"id": "123", "date": "2020-02-02", "type": None},
                 ]
-            }
+            },
         }
         with pytest.raises(ValidationError):
             self.validator.validate(some_bad_data)
 
-        empty_data = {
-            "title": "check",
-            "comment": "check",
-            "data": {
-                "account": []
-            }
-        }
+        empty_data = {"title": "check", "comment": "check", "data": {"account": []}}
         with pytest.raises(ValidationError):
             self.validator.validate(empty_data)


### PR DESCRIPTION
# What? 
Blacken files and add black python code format checker stage to CI pipeline.

# Why?
So that there's going to be a common code style between the fire repo and its clients/users (where fire is a subrepo). And this code style match will be enforced in CI black check.

# How? 
run `$black . ` locally and then run `$black . --check` in CI pipeline. 