### PR TITLE
Add cb_haircut to loan schema

### DIFF
--- a/v1-dev/loan.json
+++ b/v1-dev/loan.json
@@ -72,6 +72,12 @@
       "description": "The unique identifier for the behavioral curve used by the financial institution.",
       "type": "string"
     },
+    "cb_haircut": {
+      "description": "The haircut as determined by the firm's central bank",
+      "type": "number",
+      "minimum": 0.0,
+      "maximum": 1.0
+    },
     "ccf": {
       "$ref": "https://raw.githubusercontent.com/SuadeLabs/fire/master/v1-dev/common.json#/ccf"
     },
@@ -428,10 +434,10 @@
       "description": "Describes if the loan is active or been cancelled.",
       "type": "string",
       "enum": [
-        "actual", 
+        "actual",
         "cancellable",
-        "cancelled",  
-        "committed", 
+        "cancelled",
+        "committed",
         "defaulted"
       ]
     },


### PR DESCRIPTION
Add cb_haircut to loan schema so that user can identify which loans are eligible for central bank under C66/PRA110. Similar to how cb_haircut is used in security schema.