### PR TITLE
change json schema version from draft-04 to draft-06

### DIFF
--- a/v1-dev/account.json
+++ b/v1-dev/account.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Account Schema",
   "description": "An Account represents a financial account that describes the funds that a customer has entrusted to a financial institution in the form of deposits or credit balances.",
   "type": "object",

--- a/v1-dev/account.json
+++ b/v1-dev/account.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Account Schema",
   "description": "An Account represents a financial account that describes the funds that a customer has entrusted to a financial institution in the form of deposits or credit balances.",
   "type": "object",

--- a/v1-dev/adjustment.json
+++ b/v1-dev/adjustment.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Adjustment Schema",
   "description": "An adjustment represents a modification to a report.",
   "type": "object",

--- a/v1-dev/adjustment.json
+++ b/v1-dev/adjustment.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Adjustment Schema",
   "description": "An adjustment represents a modification to a report.",
   "type": "object",

--- a/v1-dev/agreement.json
+++ b/v1-dev/agreement.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Agreement Schema",
   "description": "An agreement represents the standard terms agreed between two parties.",
   "type": "object",

--- a/v1-dev/agreement.json
+++ b/v1-dev/agreement.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Agreement Schema",
   "description": "An agreement represents the standard terms agreed between two parties.",
   "type": "object",

--- a/v1-dev/batch.json
+++ b/v1-dev/batch.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Batch Schema",
   "description": "FIRE schema for representing bulk collections of bank objects.",
   "type": "object",

--- a/v1-dev/batch.json
+++ b/v1-dev/batch.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Batch Schema",
   "description": "FIRE schema for representing bulk collections of bank objects.",
   "type": "object",

--- a/v1-dev/collateral.json
+++ b/v1-dev/collateral.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Collateral Schema",
   "description": "Data schema to define collateral (currently can reference loans or accounts).",
   "type": "object",

--- a/v1-dev/collateral.json
+++ b/v1-dev/collateral.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Collateral Schema",
   "description": "Data schema to define collateral (currently can reference loans or accounts).",
   "type": "object",

--- a/v1-dev/curve.json
+++ b/v1-dev/curve.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Curve Schema",
   "description": "A Curve represents a series of points on a plot. Typically, interest rates, volatility or forward prices.",
   "type": "object",

--- a/v1-dev/curve.json
+++ b/v1-dev/curve.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Curve Schema",
   "description": "A Curve represents a series of points on a plot. Typically, interest rates, volatility or forward prices.",
   "type": "object",

--- a/v1-dev/customer.json
+++ b/v1-dev/customer.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Customer Schema",
   "description": "Data schema to define a customer or legal entity related to a financial product or transaction.",
   "type": "object",

--- a/v1-dev/customer.json
+++ b/v1-dev/customer.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Customer Schema",
   "description": "Data schema to define a customer or legal entity related to a financial product or transaction.",
   "type": "object",

--- a/v1-dev/derivative.json
+++ b/v1-dev/derivative.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Derivative Schema",
   "description": "A derivative is a contract which derives its value from an underlying reference index, security or asset.",
   "type": "object",

--- a/v1-dev/derivative.json
+++ b/v1-dev/derivative.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Derivative Schema",
   "description": "A derivative is a contract which derives its value from an underlying reference index, security or asset.",
   "type": "object",

--- a/v1-dev/derivative_cash_flow.json
+++ b/v1-dev/derivative_cash_flow.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Derivative Cash Flow Schema",
   "description": "A derivative cash flow where two parties exchange cash flows (or assets) derived from an underlying reference index, security or financial instrument.",
   "type": "object",

--- a/v1-dev/derivative_cash_flow.json
+++ b/v1-dev/derivative_cash_flow.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Derivative Cash Flow Schema",
   "description": "A derivative cash flow where two parties exchange cash flows (or assets) derived from an underlying reference index, security or financial instrument.",
   "type": "object",

--- a/v1-dev/entity.json
+++ b/v1-dev/entity.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Entity Schema",
   "description": "Data schema to define a person or legal entity.",
   "type": "object",

--- a/v1-dev/entity.json
+++ b/v1-dev/entity.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Entity Schema",
   "description": "Data schema to define a person or legal entity.",
   "type": "object",

--- a/v1-dev/example.json
+++ b/v1-dev/example.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "http://json-schema.org/draft-06/schema#",
+	"$schema": "http://json-schema.org/draft-07/schema#",
 	"title": "Example Schema",
 	"description": "FIRE schema for representing and validating FIRE examples",
 	"type": "object",

--- a/v1-dev/exchange_rate.json
+++ b/v1-dev/exchange_rate.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Exchange Rate Schema",
   "description": "An Exchange Rate represents the conversion rate between two currencies.",
   "type": "object",

--- a/v1-dev/exchange_rate.json
+++ b/v1-dev/exchange_rate.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Exchange Rate Schema",
   "description": "An Exchange Rate represents the conversion rate between two currencies.",
   "type": "object",

--- a/v1-dev/guarantor.json
+++ b/v1-dev/guarantor.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Guarantor Schema",
   "description": "Data schema to define a guarantor for a security.",
   "type": "object",

--- a/v1-dev/guarantor.json
+++ b/v1-dev/guarantor.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Guarantor Schema",
   "description": "Data schema to define a guarantor for a security.",
   "type": "object",

--- a/v1-dev/issuer.json
+++ b/v1-dev/issuer.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Issuer Schema",
   "description": "Data schema to define an issuer for a security.",
   "type": "object",

--- a/v1-dev/issuer.json
+++ b/v1-dev/issuer.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Issuer Schema",
   "description": "Data schema to define an issuer for a security.",
   "type": "object",

--- a/v1-dev/loan.json
+++ b/v1-dev/loan.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Loan Schema",
   "description": "Data schema defining the characteristics of a loan product.",
   "type": "object",

--- a/v1-dev/loan.json
+++ b/v1-dev/loan.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Loan Schema",
   "description": "Data schema defining the characteristics of a loan product.",
   "type": "object",

--- a/v1-dev/loan_transaction.json
+++ b/v1-dev/loan_transaction.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Loan Transaction Schema",
   "description": "A Loan Transaction is an event that has an impact on a loan, typically the balance.",
   "type": "object",

--- a/v1-dev/loan_transaction.json
+++ b/v1-dev/loan_transaction.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Loan Transaction Schema",
   "description": "A Loan Transaction is an event that has an impact on a loan, typically the balance.",
   "type": "object",

--- a/v1-dev/security.json
+++ b/v1-dev/security.json
@@ -1,6 +1,6 @@
 
 {
-  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Security Schema",
   "description": "A security represents a tradable financial instrument held or financed by an institution for investment or collateral.",
   "type": "object",

--- a/v1-dev/security.json
+++ b/v1-dev/security.json
@@ -1,6 +1,6 @@
 
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-06/schema#",
   "title": "Security Schema",
   "description": "A security represents a tradable financial instrument held or financed by an institution for investment or collateral.",
   "type": "object",


### PR DESCRIPTION
Ran a draft-06 validator on all our json schema files and they all look fine (so we're not using any draft-04 features that are incompatible with draft-06).