### PR TITLE
adding collateral type security, security id in collateral schema

### DIFF
--- a/documentation/properties/type.md
+++ b/documentation/properties/type.md
@@ -1068,7 +1068,6 @@ collateral that cannot be classified as residential or commercial property.
 ### farm
 *NEEDS Definition*
 
-
 ### guarantee
 *NEEDS Definition*
 
@@ -1082,7 +1081,7 @@ collateral that cannot be classified as residential or commercial property.
 *NEEDS Definition*
 
 ### security
-This identifies that the piece of collateral used is a security, as mapped via the security schema
+This identifies that the piece of collateral used is a security, as mapped via the security schema and linked to the collateral schema using the collateral's `security_id` property.
 
 ### other
 *NEEDS Definition*

--- a/documentation/properties/type.md
+++ b/documentation/properties/type.md
@@ -1042,6 +1042,7 @@ The most common XCS, and that traded in interbank markets, is a mark-to-market (
 ├── debenture
 ├── life_policy
 ├── cash
+├── security 
 └── other
 ```
 The collateral type defines the form of the collateral, such as property or other assets used to secure an obligation.
@@ -1079,6 +1080,9 @@ collateral that cannot be classified as residential or commercial property.
 
 ### cash
 *NEEDS Definition*
+
+### security
+This identifies that the piece of collateral used is a security, as mapped via the security schema
 
 ### other
 *NEEDS Definition*

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -64,6 +64,7 @@ class TestDocs(unittest.TestCase):
             "risk_weight_std",
             "row",
             "settlement_type",
+            "security_id",
             "theta",
             "title",
             "underlying_derivative_id",

--- a/v1-dev/collateral.json
+++ b/v1-dev/collateral.json
@@ -64,7 +64,7 @@
       "$ref": "https://raw.githubusercontent.com/SuadeLabs/fire/master/v1-dev/common.json#/regulatory_book"
     },
     "security_id": {
-      "description": ""The unique identifier used by the financial institution to identify the security representing collateral.",
+      "description": "The unique identifier used by the financial institution to identify the security representing collateral.",
       "type": "string"
     },
     "source": {

--- a/v1-dev/collateral.json
+++ b/v1-dev/collateral.json
@@ -63,6 +63,10 @@
     "regulatory_book": {
       "$ref": "https://raw.githubusercontent.com/SuadeLabs/fire/master/v1-dev/common.json#/regulatory_book"
     },
+    "security_id": {
+      "description": ""The unique identifier used by the financial institution to identify the security representing collateral.",
+      "type": "string"
+    },
     "source": {
       "description": "The source(s) where this data originated. If more than one source needs to be stored for data lineage, it should be separated by a dash. eg. Source1-Source2",
       "type": "string"
@@ -85,7 +89,8 @@
         "life_policy",
         "multifamily",
         "other",
-        "residential_property"
+        "residential_property",
+	"security"
       ]
     },
     "value": {


### PR DESCRIPTION
adding capability to add a security to a loan via the collateral schema. allows for many to many mappings of loans and security collateral.