### PR TITLE
deferred_tax as child of deferred

### DIFF
--- a/documentation/properties/type.md
+++ b/documentation/properties/type.md
@@ -795,6 +795,7 @@ Index securities are reference records recording the details of an index using t
 ├── non_product
 │   ├── amortisation
 │   ├── deferred
+│   │   └──deferred_tax
 │   ├── depreciation
 │   ├── expense
 │   ├── income
@@ -915,14 +916,25 @@ This is an overarching term used to define any non-product accounts that may exi
 ### amortisation
 An account which holds the **amortisation amount** of intangible assets measured at cost model. IAS 38.74 defines cost model measurement of intangible assets as follow:
 > After initial recognition intangible assets should be carried at cost less accumulated **amortisation** and impairment losses
+
 ### depreciation
 An account representing the change in value attributable (over a period) to assets where depreciation must be accounted for.
+
 ### deferred
 A **deferred** account is an account in which the recognition of certain revenue or expenses on the income statement is delayed for a certain period of time. For example, a deferred tax asset, which is reported in F1.01 of FINREP,  is defined by IAS 12.5 as follows:
 > the amounts of income taxes recoverable in future periods in respect of:
 (a) deductible temporary differences;
 (b) the carryforward of unused tax losses; and
 (c) the carryforward of unused tax credits.
+
+### deferred_tax
+Deferred tax liabilities are the amounts of income taxes payable in future periods in respect of taxable temporary differences.
+Deferred tax assets are the amounts of income taxes recoverable in future periods in respect of:
+
+(a) deductible temporary differences;
+(b) the carry forward of unused tax losses; and
+(c) the carry forward of unused tax credits.
+[deferred_tax]: https://www.ifrs.org/issued-standards/list-of-standards/ias-12-income-taxes/
 
 ### non_deferred
 Undeferred is used to avoid confusion with a customer current account. This is in reference to a current asset or current liability eg. (current tax liability) where it is recognised typically within the next 12 months.

--- a/v1-dev/account.json
+++ b/v1-dev/account.json
@@ -466,6 +466,7 @@
         "credit_card",
         "current",
         "deferred",
+        "deferred_tax",
         "depreciation",
         "expense",
         "income",


### PR DESCRIPTION
We need a way to have different types of deferred tax liabilities/assets for both finrep and BCAR
e.g. Deferred tax liabilities relating to computer software we can map as type = deferred_tax, purpose = computer_software

Seems we need to be able to distinguish between a few different purposes of deferred tax accounts (goodwill, CS etc)