### PR TITLE
addition of delta

### DIFF
--- a/examples/cds_index.json
+++ b/examples/cds_index.json
@@ -11,6 +11,7 @@
         "underlying_security_id": "cdx_na_ig",
         "leg_type": "indexed",
         "position": "short",
+        "delta":1,
         "currency_code": "USD",
         "notional_amount": 100,
         "trade_date": "2018-07-01T00:00:00",

--- a/examples/cds_index.json
+++ b/examples/cds_index.json
@@ -11,7 +11,7 @@
         "underlying_security_id": "cdx_na_ig",
         "leg_type": "indexed",
         "position": "short",
-        "delta":1,
+        "delta":-1,
         "currency_code": "USD",
         "notional_amount": 100,
         "trade_date": "2018-07-01T00:00:00",

--- a/examples/cds_single_name.json
+++ b/examples/cds_single_name.json
@@ -11,7 +11,7 @@
         "underlying_security_id": "Corp_Jul28",
         "leg_type": "indexed",
         "position": "short",
-        "delta":1,
+        "delta":-1,
         "currency_code": "USD",
         "notional_amount": 100,
         "trade_date": "2018-07-01T00:00:00",

--- a/examples/cds_single_name.json
+++ b/examples/cds_single_name.json
@@ -11,6 +11,7 @@
         "underlying_security_id": "Corp_Jul28",
         "leg_type": "indexed",
         "position": "short",
+        "delta":1,
         "currency_code": "USD",
         "notional_amount": 100,
         "trade_date": "2018-07-01T00:00:00",


### PR DESCRIPTION
The FIRE documentation for CDS Index and Single name should be updated to include the field "delta" as this used to determine the position long typically delta '-1' or short '1'. Both of the JSON files are short in this case. 