### PR TITLE
feat: add loan cash flow schema

### DIFF
--- a/documentation/properties/amount.md
+++ b/documentation/properties/amount.md
@@ -1,7 +1,7 @@
 ---
 layout:     property
 title:      "amount"
-schemas:    [loan_transaction]
+schemas:    [loan_cash_flow, loan_transaction]
 ---
 
 # amount

--- a/documentation/properties/date.md
+++ b/documentation/properties/date.md
@@ -1,7 +1,7 @@
 ---
 layout:		property
 title:		"date"
-schemas:	[account, collateral, customer, derivative_cash_flow, derivative, entity, exchange_rate, guarantor, issuer, loan_transaction, loan, security]
+schemas:	[account, collateral, customer, derivative_cash_flow, derivative, entity, exchange_rate, guarantor, issuer, loan_cash_flow, loan_transaction, loan, security]
 ---
 
 # date

--- a/documentation/properties/id.md
+++ b/documentation/properties/id.md
@@ -1,7 +1,7 @@
 ---
 layout:		property
 title:		"id"
-schemas:	[account, collateral, customer, derivative_cash_flow, derivative, exchange_rate, guarantor, issuer, loan_transaction, loan, security]
+schemas:	[account, collateral, customer, derivative_cash_flow, derivative, exchange_rate, guarantor, issuer, loan_cash_flow, loan_transaction, loan, security]
 ---
 
 # id

--- a/documentation/properties/source.md
+++ b/documentation/properties/source.md
@@ -1,7 +1,7 @@
 ---
 layout:		property
 title:		"source"
-schemas:	[account, collateral, customer, derivative_cash_flow, derivative, loan_transaction, loan, security]
+schemas:	[account, collateral, customer, derivative_cash_flow, derivative, loan_cash_flow, loan_transaction, loan, security]
 ---
 
 # source

--- a/documentation/properties/type.md
+++ b/documentation/properties/type.md
@@ -1,7 +1,7 @@
 ---
 layout:     property
 title:      "type"
-schemas:    [account, agreement, collateral, customer, derivative_cash_flow, derivative, entity, guarantor, issuer, loan_transaction, loan, security]
+schemas:    [account, agreement, collateral, customer, derivative_cash_flow, derivative, entity, guarantor, issuer, loan_cash_flow, loan_transaction, loan, security]
 ---
 
 # type
@@ -133,11 +133,11 @@ Article 411 of the [CRR][crr]:
 > (m) a building society
 
 ### unregulated_financial
-In the Basel guidelines for Credit Risk under exposures to securties firms and financial institutions, [CRE 20.40](https://www.bis.org/basel_framework/chapter/CRE/20.htm?tldate=20220101&inforce=20230101&published=20201126#:~:text=provided%20that%20these,their%20own%20jurisdictions.) it allows for these exposures to be treated like exposures to banks on the basis that they fall under the same regulated regime (and similar supervisory requirements) that banks in that jurisdiction are subject to. 
+In the Basel guidelines for Credit Risk under exposures to securties firms and financial institutions, [CRE 20.40](https://www.bis.org/basel_framework/chapter/CRE/20.htm?tldate=20220101&inforce=20230101&published=20201126#:~:text=provided%20that%20these,their%20own%20jurisdictions.) it allows for these exposures to be treated like exposures to banks on the basis that they fall under the same regulated regime (and similar supervisory requirements) that banks in that jurisdiction are subject to.
 So 'unregulated_financial' is to clearly define those firms *that do not* meet these regulatory requirements.
 
 As defined by OSFI chapter 4, P56 and chapter 5, P68:
-> Unregulated financial institutions are institutions that are not supervised by a regulator, and therefore NOT subject to prudential standards or any level of supervision equivalent to those applied to banks under the Basel III framework (including, in particular, capital and liquidity requirements).  
+> Unregulated financial institutions are institutions that are not supervised by a regulator, and therefore NOT subject to prudential standards or any level of supervision equivalent to those applied to banks under the Basel III framework (including, in particular, capital and liquidity requirements).
 
 Unregulated financial institutions would be not be qualified for "bank" treatment under standardized and/or subject to 1.25 correlation factor under IRB.
 
@@ -301,11 +301,11 @@ A collective investment undertaking is defined by the EU [here][lcr] Article 4(1
 
 
 ### fund
-A general term for collective investment vehicles and management companies. For example, those defined under the [US Investment Company Act 1940][inv-co-act] but not qualifying as an EU CIU. There does not appear to be a cross-jurisdictional, unified classification of types of funds 
+A general term for collective investment vehicles and management companies. For example, those defined under the [US Investment Company Act 1940][inv-co-act] but not qualifying as an EU CIU. There does not appear to be a cross-jurisdictional, unified classification of types of funds
 
 
 ### private_fund
-A private fund is a pooled investment vehicle excluded from the definition of an investment company in the [US Investment Company Act 1940][inv-co-act] 
+A private fund is a pooled investment vehicle excluded from the definition of an investment company in the [US Investment Company Act 1940][inv-co-act]
 [Private Fund](https://www.sec.gov/education/glossary/jargon-z#PEF:~:text=Private%20Equity%20Funds-,Private%20Fund,applicable%20registration%20requirements%20(for%20example%2C%20as%20an%20exempt%20reporting%20adviser).,-Want%20to%20learn)
 
 ### private_equity_fund
@@ -319,7 +319,7 @@ See also: [SEC Hedge fund bulletin][hedge-fund2]
 
 
 ### real_estate_fund
-Real estate funds or [REITS](https://www.investor.gov/introduction-investing/investing-basics/investment-products/real-estate-investment-trusts-reits). 
+Real estate funds or [REITS](https://www.investor.gov/introduction-investing/investing-basics/investment-products/real-estate-investment-trusts-reits).
 
 
 ### pension_fund
@@ -389,7 +389,7 @@ A financial holding copmany is defined by the EU [here][lcr] Article 4(1)(20):
 > (20) 'financial holding company' means a financial institution, the subsidiaries of which are exclusively or mainly institutions or financial institutions, at least one of such subsidiaries being an institution, and which is not a mixed financial holding company;
 
 ### pmi
-Private Mortgage Insurer is financial institution that provides insurance to residential mortgages that may get part of guaranteed amount backed by federal government.  Under OSFI rules, PMI guaranteed amounts may get split between a backstop and a deductiable portion.  
+Private Mortgage Insurer is financial institution that provides insurance to residential mortgages that may get part of guaranteed amount backed by federal government.  Under OSFI rules, PMI guaranteed amounts may get split between a backstop and a deductiable portion.
 
 Reference:  OSFI Chapter 4, P272-274;  Chapter 5, P146-148
 
@@ -687,7 +687,7 @@ A commercial mortgage-backed security secured by a pool of mortages that are dee
 Reference: [OSFI BCAR, section 4.1.12](https://www.osfi-bsif.gc.ca/Eng/fi-if/rg-ro/gdn-ort/gl-ld/Pages/CAR22_chpt4.aspx#:~:text=Income%20producing%20commercial%20real%20estate%3A%20exposures%20where%20the%20criteria%20in%20paragraph%20108%20are%20met%2C%20but%20those%20in%20paragraph%20110%20(land%20acquisition%2C%20development%20and%20construction)%20are%20not%20applicable.)
 
 ### nha_mbs
-National Housing Act (NHA) MBS that are guaranteed by the Canada Mortgage and Housing Corporation (CMHC), will receive a risk weight of 0% in recognition of the fact that obligations incurred by CMHC are legal obligations of the Government of Canada.  
+National Housing Act (NHA) MBS that are guaranteed by the Canada Mortgage and Housing Corporation (CMHC), will receive a risk weight of 0% in recognition of the fact that obligations incurred by CMHC are legal obligations of the Government of Canada.
 
 Reference: [OSFI BCAR Chapter 4, P120](https://www.osfi-bsif.gc.ca/Eng/fi-if/rg-ro/gdn-ort/gl-ld/Pages/CAR22_chpt4.aspx#:~:text=National%20Housing%20Act%20(NHA)%20MBS%20that%20are%20guaranteed%20by%20the%20Canada%20Mortgage%20and%20Housing%20Corporation%20(CMHC)%2C%20will%20receive%20a%20risk%20weight%20of%200%25%20in%20recognition%20of%20the%20fact%20that%20obligations%20incurred%20by%20CMHC%20are%20legal%20obligations%20of%20the%20Government%20of%20Canada.)
 
@@ -1101,7 +1101,7 @@ The most common XCS, and that traded in interbank markets, is a mark-to-market (
 ├── debenture
 ├── life_policy
 ├── cash
-├── security 
+├── security
 └── other
 ```
 The collateral type defines the form of the collateral, such as property or other assets used to secure an obligation.
@@ -1249,6 +1249,16 @@ An interest rate curve
 
 ### volatility
 A volatility curve (smile)
+
+
+# loan_cash_flow
+
+### interest
+A repayment that covers only the interest section of the loan, the principal borrowed amount in this case is left unchanged
+
+### principal
+A repayment that reduces the principal amount borrowed and does not include any interest component
+
 
 # loan_transaction
 

--- a/documentation/properties/version_id.md
+++ b/documentation/properties/version_id.md
@@ -1,7 +1,7 @@
 ---
 layout:		property
 title:		"version_id"
-schemas:	[account, collateral, customer, derivative_cash_flow, derivative, loan_transaction, loan, security]
+schemas:	[account, collateral, customer, derivative_cash_flow, derivative, loan_cash_flow, loan_transaction, loan, security]
 ---
 
 # version_id

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -40,7 +40,6 @@ class TestSchemas(unittest.TestCase):
                 "example.json",
                 "guarantor.json",
                 "issuer.json",
-                "reporter.json",
             ]:
                 assert not enums
             else:

--- a/v1-dev/loan_cash_flow.json
+++ b/v1-dev/loan_cash_flow.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Loan Cash Flow Schema",
+  "description": "A loan cash flow represents the future movement of cash as part of contractually agreed payments for an existing loan.",
+  "type": "object",
+  "properties": {
+    "id": {
+      "description": "The unique identifier for the record within the firm.",
+      "type": "string"
+    },
+    "date": {
+      "description": "The observation or value date for the data in this object. Formatted as YYYY-MM-DDTHH:MM:SSZ in accordance with ISO 8601.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "amount": {
+      "description": "The size of the cash flow. Monetary type represented as a naturally positive integer number of cents/pence denominated in the currency of the udnerlying loan.",
+      "type": "integer",
+      "monetary": true
+    },
+    "payment_date": {
+      "description": "The timestamp that the cash flow will occur or was paid. YYYY-MM-DDTHH:MM:SSZ in accordance with ISO 8601.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "source": {
+      "description": "The source(s) where this data originated. If more than one source needs to be stored for data lineage, it should be separated by a dash. eg. Source1-Source2",
+      "type": "string"
+    },
+    "type": {
+      "description": "The type of the payment, signifying whether interest or principal is being paid.",
+      "type": "string",
+      "enum": [
+        "interest",
+        "principal"
+      ]
+    },
+    "version_id": {
+      "description": "The version identifier of the data such as the firm's internal batch identifier.",
+      "type": "string"
+    }
+  },
+  "required": ["id", "date", "amount", "loan_id", "type"],
+  "additionalProperties": true
+}


### PR DESCRIPTION
Adds a simple loan cash flow schema (experimental).

Notes: I've deliberately left _out_ the currency code from this schema on the basis that a cash flow should not exist without a corresponding loan, and it should be denominated in the currency of the underlying loan.

Things will get _really_ complicated if we allow multiple cash flows for the same loan denominated in different currencies.