### PR TITLE
Add currency code to loan cash flow schema

### DIFF
--- a/v1-dev/loan_cash_flow.json
+++ b/v1-dev/loan_cash_flow.json
@@ -14,9 +14,12 @@
       "format": "date-time"
     },
     "amount": {
-      "description": "The size of the cash flow. Monetary type represented as a naturally positive integer number of cents/pence denominated in the currency of the udnerlying loan.",
+      "description": "The size of the cash flow. Monetary type represented as a naturally positive integer number of cents/pence denominated in the currency code.",
       "type": "integer",
       "monetary": true
+    },
+    "currency_code": {
+      "$ref": "https://raw.githubusercontent.com/SuadeLabs/fire/master/v1-dev/common.json#/currency_code"
     },
     "loan_id": {
       "description": "The unique identifier for the affected loan/s within the financial institution.",
@@ -44,6 +47,6 @@
       "type": "string"
     }
   },
-  "required": ["id", "date", "amount", "loan_id", "type"],
+  "required": ["id", "date", "amount", "currency_code", "loan_id", "type", "payment_date"],
   "additionalProperties": true
 }


### PR DESCRIPTION
This is required for the cash flow to be a stand-alone item (and generally most of our systems set up to deal with monetary fields is ill-suited to having the currency code on a joined model).

Good practice (i.e. good data quality) should require that the currency code of the cash flow is the same as that of the underlying loan.