### PR TITLE
Add `minimum_balance` to Account and Loan schema

### DIFF
--- a/documentation/properties/minimum_balance.md
+++ b/documentation/properties/minimum_balance.md
@@ -1,0 +1,14 @@
+---
+layout:		property
+title:		"minimum_balance"
+schemas:	[account, loan]
+---
+
+# minimum_balance
+
+---
+
+The minimum balance that account holders must have in their account each day, set by the bank holding the account.
+
+Indicates the minimum balance of each account within the aggregate. Monetary type represented as a naturally positive integer number of cents/pence.
+

--- a/v1-dev/account.json
+++ b/v1-dev/account.json
@@ -247,6 +247,11 @@
       "type": "integer",
       "monetary": true
     },
+    "minimum_balance": {
+      "description": "Indicates the minimum balance of each account within the aggregate. Monetary type represented as a naturally positive integer number of cents/pence.",
+      "type": "integer",
+      "monetary": true
+    },
     "minimum_balance_eur": {
       "description": "Indicates the minimum balance, in Euros, of each account within the aggregate. Monetary type represented as a naturally positive integer number of cents/pence.",
       "type": "integer",

--- a/v1-dev/loan.json
+++ b/v1-dev/loan.json
@@ -318,6 +318,11 @@
       "minimum": 0,
       "monetary": true
     },
+    "minimum_balance": {
+      "description": "Indicates the minimum balance of each loan within the aggregate.",
+      "type": "integer",
+      "monetary": true
+    },
     "minimum_balance_eur": {
       "description": "Indicates the minimum balance, in Euros, of each loan within the aggregate.",
       "type": "integer",


### PR DESCRIPTION
Updating FIRE attribute to not specifically be denominated in `_EUR`. This is to allow users to populate minimum balance values in currencies other than EUR.
`minimum_balance_eur` will be deprecated on a later date.