### PR TITLE
docs(Fire Examples): :memo: Start date should be after reporting date…

### DIFF
--- a/examples/bond_future.json
+++ b/examples/bond_future.json
@@ -14,7 +14,7 @@
         "rate": 125.5,
         "underlying_index": "BUND0829",
         "trade_date": "2019-04-01T00:00:00",
-        "start_date": "2019-04-01T00:00:00",
+        "start_date": "2019-05-02T00:00:00",
         "end_date": "2019-06-15T00:00:00",
         "last_payment_date": "2029-08-15T00:00:00",
         "settlement_type": "physical",

--- a/examples/bond_future2.json
+++ b/examples/bond_future2.json
@@ -12,7 +12,7 @@
         "currency_code": "USD",
         "notional_amount": 100,
         "trade_date": "2019-04-01T00:00:00",
-        "start_date": "2019-04-01T00:00:00",
+        "start_date": "2019-05-02T00:00:00",
         "end_date": "2021-03-15T00:00:00",
         "last_payment_date": "2041-03-15T00:00:00",
         "underlying_index": "T-bondMar41",


### PR DESCRIPTION
For bond futures, start date should be after reporting date. Having the start date in the past for the contract will yield incorrect interest rate general risk.