### PR TITLE
New status enum under unsettled

### DIFF
--- a/documentation/properties/status.md
+++ b/documentation/properties/status.md
@@ -95,6 +95,7 @@ This is a loan where the customer has defaulted or is non-performing.
 ├── called_up
 ├── bankruptcy_remote
 ├── unsettled
+    └── free_deliveries
 └── non_operational
 ```
 
@@ -123,16 +124,24 @@ This indicates that the security does not meet the requirements set in Article 8
 ### unsettled
 This indicates that the transaction is still unsettled after its due delivery date. Under the Basel framework, this transaction would be in scope for the requirements defined under [the capital treatment of unsettled transactions and failed trades][CRE70]"
 
+### free_deliveries
+
+From [CRE70.10](https://www.bis.org/basel_framework/chapter/CRE/70.htm#:~:text=Capital%20requirements%20for%20non%2DDvP%20transactions%20(free%20deliveries)), free deliveries are a specific type of unsettled transaction. Indicates that cash is paid without receipt of the corresponding receivable  (securities, foreign currencies, gold, or commodities) or, conversely, deliverables were delivered without receipt of the corresponding cash payment (non-DvP, or free deliveries) expose firms to a risk of loss on the full amount of cash paid or deliverables delivered.
+
 
 ## Derivative
 ```bash
 └── unsettled
+    └── free_deliveries
 ```
 
 ### unsettled
 
 This indicates that the transaction is still unsettled after its due delivery date. Under the Basel framework, this transaction would be in scope for the requirements defined under [the capital treatment of unsettled transactions and failed trades][CRE70]"
 
+### free_deliveries
+
+From [CRE70.10](https://www.bis.org/basel_framework/chapter/CRE/70.htm#:~:text=Capital%20requirements%20for%20non%2DDvP%20transactions%20(free%20deliveries)), free deliveries are a specific type of unsettled transaction. Indicates that cash is paid without receipt of the corresponding receivable  (securities, foreign currencies, gold, or commodities) or, conversely, deliverables were delivered without receipt of the corresponding cash payment (non-DvP, or free deliveries) expose firms to a risk of loss on the full amount of cash paid or deliverables delivered.
 
 ---
 [lcr]:  http://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32015R0061

--- a/v1-dev/derivative.json
+++ b/v1-dev/derivative.json
@@ -300,6 +300,7 @@
       "description": "Provides additional information regarding the status of the derivative.",
       "type": "string",
       "enum": [
+        "free_deliveries",
         "unsettled"
       ]
     },

--- a/v1-dev/security.json
+++ b/v1-dev/security.json
@@ -681,6 +681,7 @@
       "enum": [
         "bankruptcy_remote",
         "called_up",
+        "free_deliveries",
         "non_operational",
         "paid_up",
         "unsettled"


### PR DESCRIPTION
Corresponds to the following GL issues; [one](https://gitlab.suade.io/suade/customers/-/issues/761) & [two](https://gitlab.suade.io/suade/Services/-/issues/15590). Regulations can be found [here](https://www.bis.org/basel_framework/chapter/CRE/70.htm).

Proposal to add a new enum to security/ derivative status under the **unsettled** enum as there are specific reports where this distinction is referenced.

For example C11.00 Settlement/Delivery Risk, we have the note from [here - page 135](https://www.bankofengland.co.uk/-/media/boe/files/prudential-regulation/regulatory-reporting/banking/corep-own-funds-instructions.pdf)

> 105.Note that own funds requirements for free deliveries as laid down in Article 379
CRR are not within the scope of the CR SETT template. Those own funds
requirements shall be reported in the credit risk templates (CR SA, CR IRB).
3.6.2. Instructions concerning specific positions
