### PR TITLE
Add new enum 'main_index_equity' under security type equity

### DIFF
--- a/documentation/properties/type.md
+++ b/documentation/properties/type.md
@@ -536,6 +536,7 @@ Other refers to a type of security not covered by the above. If you find yoursel
 │   │   └── pref_share
 │   ├── share_agg
 │   └── speculative_unlisted
+│   └── main_index_equity
 ├── debt
 │   ├── bond
 │   ├── covered_bond
@@ -609,6 +610,9 @@ As per OSFI and BCBS, a Speculative unlisted equity is defined as "an equity inv
 
 ### treasury
 According to IAS 32.33, if an entity reacquires its own equity instruments, those instruments shall be considered **treasury shares**, and shall be deducted from equity.
+
+### main_index_equity
+The main_index_equity identifies equities that are constituents of a main index for the purposes of applying a volatility adjustment in line with [Article 224](https://www.eba.europa.eu/regulation-and-policy/single-rulebook/interactive-single-rulebook/16006).
 
 ### debt
 This is a "catch all" term for debt of any kind, *bond*, *bond_amortising*, *covered_bond*, *abs*, *residential_mbs*, *non_residential_mbs*, *frn*, *govt_gteed_frn*, to be used when further granularity is not available or not needed.

--- a/v1-dev/security.json
+++ b/v1-dev/security.json
@@ -741,6 +741,7 @@
         "index",
         "index_linked",
         "letter_of_credit",
+        "main_index_equity",
         "mbs",
         "mtn",
         "nha_mbs",


### PR DESCRIPTION
Proposal to add new main_index_equity as a child of the equity security type.

The main_index_equity sub-type is used to identify equities that are constituents of a main index for the purposes of applying a volatility adjustment in line with [Article 224](https://www.eba.europa.eu/regulation-and-policy/single-rulebook/interactive-single-rulebook/16006). 

Previously in order to map these products, the **product_name** field included the main index name, but this overlaps with the rationale and benefit behind this property as firms may have pre-existing designation for the **product_name**. 

Refers to this GL [issue](https://gitlab.suade.io/suade/Services/-/issues/15656) 