### PR TITLE
addition of new cum_write_off column

### DIFF
--- a/documentation/properties/cum_write_offs.md
+++ b/documentation/properties/cum_write_offs.md
@@ -1,0 +1,15 @@
+---
+layout:     property
+title:      "cum_write_offs"
+schemas:    [loan]
+---
+
+# cum_write_offs
+
+---
+
+**cum_write_offs** is the unique identifier under the loan schema where one loan was partially written off and retains an impairment type individual or collective.
+
+These refer to cumulative balances where an entity has no reasonable expectations of recovering the contractual cash flows on a financial asset in its entirety or a portion thereof.
+
+See (https://www.ifrs.org/content/dam/ifrs/publications/pdf-standards/english/2022/issued/part-a/ifrs-9-financial-instruments.pdf?bypass=on)

--- a/documentation/properties/cum_write_offs.md
+++ b/documentation/properties/cum_write_offs.md
@@ -8,8 +8,9 @@ schemas:    [loan]
 
 ---
 
-**cum_write_offs** is the unique identifier under the loan schema where one loan was partially written off and retains an impairment type individual or collective.
-
-These refer to cumulative balances where an entity has no reasonable expectations of recovering the contractual cash flows on a financial asset in its entirety or a portion thereof.
+**cum_write_offs** refer to cumulative balances where an entity has no reasonable expectations of recovering the contractual cash flows on a financial asset in its entirety or a portion thereof.
+ 
+Used to represent the portion of the loan which has been written off, separate to any portion that may remain impaired or unimpaired.
 
 See (https://www.ifrs.org/content/dam/ifrs/publications/pdf-standards/english/2022/issued/part-a/ifrs-9-financial-instruments.pdf?bypass=on)
+

--- a/v1-dev/loan.json
+++ b/v1-dev/loan.json
@@ -119,6 +119,12 @@
       "minimum": 0,
       "monetary": true
     },
+    "cum_write_offs": {
+      "description": "Contains monetary value where one loan was partially written off and retains an impairment type individual or collective.",
+      "type": "integer",
+      "minimum": 0,
+      "monetary": true
+    },
     "currency_code": {
       "$ref": "https://raw.githubusercontent.com/SuadeLabs/fire/master/v1-dev/common.json#/currency_code"
     },

--- a/v1-dev/loan.json
+++ b/v1-dev/loan.json
@@ -120,7 +120,7 @@
       "monetary": true
     },
     "cum_write_offs": {
-      "description": "Contains monetary value where one loan was partially written off and retains an impairment type individual or collective.",
+      "description": "The portion of the loan which has been written off.",
       "type": "integer",
       "minimum": 0,
       "monetary": true


### PR DESCRIPTION
I have created a new column "cum_write_offs" on the loans schema. This is concerned with cases where one loan was partially written off and retains an impairment type individual or collective. Currently, "Write_offs" are identified via Loans schema column "Impairment_type", where there's also gathered information on "Collective and "Individual" allowances.