### PR TITLE
add ciu types as children of share under security

### DIFF
--- a/documentation/properties/type.md
+++ b/documentation/properties/type.md
@@ -534,6 +534,18 @@ Other refers to a type of security not covered by the above. If you find yoursel
 │   ├── share
 │   │   ├── treasury
 │   │   └── pref_share
+│   │   └── ciu_lvl_1_cash_cb
+│   │   └── ciu_lvl_1_excl_cov
+│   │   └── ciu_lvl_1_cov_bond
+│   │   └── ciu_lvl_2a_corp_bond
+│   │   └── ciu_lvl_2a_cov_bond
+│   │   └── ciu_lvl_2a_public_sec
+│   │   └── ciu_lvl_2b_rmbs_auto
+│   │   └── ciu_lvl_2b_cov_bond
+│   │   └── ciu_lvl_2b_abs_oth
+│   │   └── ciu_lvl_2b_corp_bond
+│   │   └── ciu_lvl_2b_shares
+│   │   └── ciu_lvl_2b_public_sec
 │   ├── share_agg
 │   └── speculative_unlisted
 │   └── main_index_equity
@@ -613,6 +625,42 @@ According to IAS 32.33, if an entity reacquires its own equity instruments, thos
 
 ### main_index_equity
 The main_index_equity identifies equities that are constituents of a main index for the purposes of applying a volatility adjustment in line with [Article 224](https://www.eba.europa.eu/regulation-and-policy/single-rulebook/interactive-single-rulebook/16006).
+
+### ciu_lvl_1_cash_cb
+CIU where the underlying is Level 1 coins/banknotes and/or central bank exposures
+
+### ciu_lvl_1_excl_cov_bond
+CIU where the underlying is Level 1 assets excluding extremely high quality covered bonds
+
+### ciu_lvl_1_cov_bond
+CIU where the underlying is Level 1 extremely high quality covered bonds
+
+### ciu_lvl_2a_corp_bond
+CIU where the underlying is Level 2A corporate debt securities (CQS1)
+
+### ciu_lvl_2a_cov_bond
+CIU where the underlying is Level 2A high quality covered bonds (CQS1/2)
+
+### ciu_lvl_2a_public_sec
+CIU where the underlying is Level 2A claims on or guaranteed by central governments, central banks, regional governments, local authorities or public sector entities
+
+### ciu_lvl_2b_rmbs_auto
+CIU where the underlying is Level 2B asset-backed securities (residential or auto)
+
+### ciu_lvl_2b_cov_bond
+CIU where the underlying is Level 2B High quality covered bonds
+
+### ciu_lvl_2b_corp_bond
+CIU where the underlying is Level 2B asset-backed securities (commercial or individuals)
+
+### ciu_lvl_2b_abs_oth
+CIU where the underlying is Level 2B corporate debt securities (CQS2/3)
+
+### ciu_lvl_2b_shares
+CIU where the underlying is Level 2B shares (major stock index)
+
+### ciu_lvl_2b_public_sec
+CIU where the underlying is Level 2B claims on or guaranteed by central governments, central banks, regional governments, local authorities or public sector entities
 
 ### debt
 This is a "catch all" term for debt of any kind, *bond*, *bond_amortising*, *covered_bond*, *abs*, *residential_mbs*, *non_residential_mbs*, *frn*, *govt_gteed_frn*, to be used when further granularity is not available or not needed.


### PR DESCRIPTION
Added new child enums of Share for the type property on the security schema. Refer to the FIRE documentation for more details

- ciu_lvl_1_cash_cb
- ciu_lvl_1_excl_cov_bond
- ciu_lvl_1_cov_bond
- ciu_lvl_2a_corp_bond
- ciu_lvl_2a_cov_bond
- ciu_lvl_2a_public_sec
- ciu_lvl_2b_rmbs_auto
- ciu_lvl_2b_cov_bond
- ciu_lvl_2b_corp_bond
- ciu_lvl_2b_abs_oth
- ciu_lvl_2b_shares
- ciu_lvl_2b_public_sec

Reference issue: https://gitlab.suade.io/suade/Services/-/issues/15986