### PR TITLE
Update cash ratio deposit definition

### DIFF
--- a/documentation/properties/type.md
+++ b/documentation/properties/type.md
@@ -534,18 +534,6 @@ Other refers to a type of security not covered by the above. If you find yoursel
 │   ├── share
 │   │   ├── treasury
 │   │   └── pref_share
-│   │   └── ciu_lvl_1_cash_cb
-│   │   └── ciu_lvl_1_excl_cov
-│   │   └── ciu_lvl_1_cov_bond
-│   │   └── ciu_lvl_2a_corp_bond
-│   │   └── ciu_lvl_2a_cov_bond
-│   │   └── ciu_lvl_2a_public_sec
-│   │   └── ciu_lvl_2b_rmbs_auto
-│   │   └── ciu_lvl_2b_cov_bond
-│   │   └── ciu_lvl_2b_abs_oth
-│   │   └── ciu_lvl_2b_corp_bond
-│   │   └── ciu_lvl_2b_shares
-│   │   └── ciu_lvl_2b_public_sec
 │   ├── share_agg
 │   └── speculative_unlisted
 │   └── main_index_equity
@@ -625,42 +613,6 @@ According to IAS 32.33, if an entity reacquires its own equity instruments, thos
 
 ### main_index_equity
 The main_index_equity identifies equities that are constituents of a main index for the purposes of applying a volatility adjustment in line with [Article 224](https://www.eba.europa.eu/regulation-and-policy/single-rulebook/interactive-single-rulebook/16006).
-
-### ciu_lvl_1_cash_cb
-CIU where the underlying is Level 1 coins/banknotes and/or central bank exposures
-
-### ciu_lvl_1_excl_cov_bond
-CIU where the underlying is Level 1 assets excluding extremely high quality covered bonds
-
-### ciu_lvl_1_cov_bond
-CIU where the underlying is Level 1 extremely high quality covered bonds
-
-### ciu_lvl_2a_corp_bond
-CIU where the underlying is Level 2A corporate debt securities (CQS1)
-
-### ciu_lvl_2a_cov_bond
-CIU where the underlying is Level 2A high quality covered bonds (CQS1/2)
-
-### ciu_lvl_2a_public_sec
-CIU where the underlying is Level 2A claims on or guaranteed by central governments, central banks, regional governments, local authorities or public sector entities
-
-### ciu_lvl_2b_rmbs_auto
-CIU where the underlying is Level 2B asset-backed securities (residential or auto)
-
-### ciu_lvl_2b_cov_bond
-CIU where the underlying is Level 2B High quality covered bonds
-
-### ciu_lvl_2b_corp_bond
-CIU where the underlying is Level 2B asset-backed securities (commercial or individuals)
-
-### ciu_lvl_2b_abs_oth
-CIU where the underlying is Level 2B corporate debt securities (CQS2/3)
-
-### ciu_lvl_2b_shares
-CIU where the underlying is Level 2B shares (major stock index)
-
-### ciu_lvl_2b_public_sec
-CIU where the underlying is Level 2B claims on or guaranteed by central governments, central banks, regional governments, local authorities or public sector entities
 
 ### debt
 This is a "catch all" term for debt of any kind, *bond*, *bond_amortising*, *covered_bond*, *abs*, *residential_mbs*, *non_residential_mbs*, *frn*, *govt_gteed_frn*, to be used when further granularity is not available or not needed.

--- a/documentation/properties/type.md
+++ b/documentation/properties/type.md
@@ -752,7 +752,7 @@ As defined in [LCR Regulations Article 10 on Liquid Assets][lcr]:
 > include balances receivable on demand at central banks.
 
 ### cash_ratio_deposit
-The [BofE](http://www.bankofengland.co.uk/statistics/Documents/faq/crds.pdf) defines this as:
+The [BofE](https://www.bankofengland.co.uk/statistics/notice/2024/statistical-notice-2024-08) defines this as:
 > The Levy will be applied on a proportional basis, which means that the Bank will allocate the policy costs to be recovered by the Levy in proportion to an eligible institution’s liability base. Eligible liabilities are defined in the Glossary. This will be a continuation of how the CRD scheme operated. The policy rationale for using the eligible liability base is the link between the size of a financial institution’s liabilities and its potential impact on the Bank’s financial stability and monetary policy functions.
 
 ### guarantee

--- a/documentation/properties/type.md
+++ b/documentation/properties/type.md
@@ -801,7 +801,7 @@ As defined in [LCR Regulations Article 10 on Liquid Assets][lcr]:
 
 ### cash_ratio_deposit
 The [BofE](http://www.bankofengland.co.uk/statistics/Documents/faq/crds.pdf) defines this as:
-> non-interest bearing deposits lodged with the Bank of England by eligible institutions (ie. banks and building societies), who have reported average eligible liabilities (ELs) of over £600 million over a calculation period. The level of each institution's CRD is currently calculated twice-yearly (currently in May and November) at 0.18% of average ELs, over the previous six end-calendar months, in excess of £600mn. The value bands and ratios were specified by HM Treasury in the Cash Ratio Deposits (Value Bands and Ratios) Order (2013 No 1189).
+> The Levy will be applied on a proportional basis, which means that the Bank will allocate the policy costs to be recovered by the Levy in proportion to an eligible institution’s liability base. Eligible liabilities are defined in the Glossary. This will be a continuation of how the CRD scheme operated. The policy rationale for using the eligible liability base is the link between the size of a financial institution’s liabilities and its potential impact on the Bank’s financial stability and monetary policy functions.
 
 ### guarantee
 From EU [Supervisory Reporting][sup-rep] part 2(9):

--- a/documentation/properties/type.md
+++ b/documentation/properties/type.md
@@ -534,6 +534,18 @@ Other refers to a type of security not covered by the above. If you find yoursel
 │   ├── share
 │   │   ├── treasury
 │   │   └── pref_share
+│   │   └── ciu_lvl_1_cash_cb
+│   │   └── ciu_lvl_1_excl_cov
+│   │   └── ciu_lvl_1_cov_bond
+│   │   └── ciu_lvl_2a_corp_bond
+│   │   └── ciu_lvl_2a_cov_bond
+│   │   └── ciu_lvl_2a_public_sec
+│   │   └── ciu_lvl_2b_rmbs_auto
+│   │   └── ciu_lvl_2b_cov_bond
+│   │   └── ciu_lvl_2b_abs_oth
+│   │   └── ciu_lvl_2b_corp_bond
+│   │   └── ciu_lvl_2b_shares
+│   │   └── ciu_lvl_2b_public_sec
 │   ├── share_agg
 │   └── speculative_unlisted
 │   └── main_index_equity
@@ -613,6 +625,42 @@ According to IAS 32.33, if an entity reacquires its own equity instruments, thos
 
 ### main_index_equity
 The main_index_equity identifies equities that are constituents of a main index for the purposes of applying a volatility adjustment in line with [Article 224](https://www.eba.europa.eu/regulation-and-policy/single-rulebook/interactive-single-rulebook/16006).
+
+### ciu_lvl_1_cash_cb
+CIU where the underlying is Level 1 coins/banknotes and/or central bank exposures
+
+### ciu_lvl_1_excl_cov_bond
+CIU where the underlying is Level 1 assets excluding extremely high quality covered bonds
+
+### ciu_lvl_1_cov_bond
+CIU where the underlying is Level 1 extremely high quality covered bonds
+
+### ciu_lvl_2a_corp_bond
+CIU where the underlying is Level 2A corporate debt securities (CQS1)
+
+### ciu_lvl_2a_cov_bond
+CIU where the underlying is Level 2A high quality covered bonds (CQS1/2)
+
+### ciu_lvl_2a_public_sec
+CIU where the underlying is Level 2A claims on or guaranteed by central governments, central banks, regional governments, local authorities or public sector entities
+
+### ciu_lvl_2b_rmbs_auto
+CIU where the underlying is Level 2B asset-backed securities (residential or auto)
+
+### ciu_lvl_2b_cov_bond
+CIU where the underlying is Level 2B High quality covered bonds
+
+### ciu_lvl_2b_corp_bond
+CIU where the underlying is Level 2B asset-backed securities (commercial or individuals)
+
+### ciu_lvl_2b_abs_oth
+CIU where the underlying is Level 2B corporate debt securities (CQS2/3)
+
+### ciu_lvl_2b_shares
+CIU where the underlying is Level 2B shares (major stock index)
+
+### ciu_lvl_2b_public_sec
+CIU where the underlying is Level 2B claims on or guaranteed by central governments, central banks, regional governments, local authorities or public sector entities
 
 ### debt
 This is a "catch all" term for debt of any kind, *bond*, *bond_amortising*, *covered_bond*, *abs*, *residential_mbs*, *non_residential_mbs*, *frn*, *govt_gteed_frn*, to be used when further granularity is not available or not needed.


### PR DESCRIPTION
 - Updated the definition of the cash_ratio_deposit enum to reflect the changes implemented by the BoE on that scheme.
- The BoE announced on 1 March 2024 the transition from the Cash ratio deposit (CRD) scheme to the Bank of England Levy ("the Levy"). According to the amendments made to the Bank of England Act 1998, the CRD scheme is no longer in effect and has been omitted and replaced with "the levy".