### PR TITLE
Update arrears balance definition

### DIFF
--- a/v1-dev/account.json
+++ b/v1-dev/account.json
@@ -27,7 +27,7 @@
       "monetary": true
     },
     "arrears_balance": {
-      "description": "The balance of the capital amount that is considered to be in arrears (for overdrafts/credit cards). Monetary type represented as a naturally positive integer number of cents/pence.",
+      "description": "The balance of the capital amount that is considered to be in arrears (for overdrafts/credit cards). Monetary type represented as an integer of cents/pence.",
       "type": "integer",
       "monetary": true
     },

--- a/v1-dev/loan.json
+++ b/v1-dev/loan.json
@@ -58,7 +58,7 @@
       ]
     },
     "arrears_balance": {
-      "description": "The balance of the loan or capital amount that is considered to be in arrears. Monetary type represented as a naturally positive integer number of cents/pence.",
+      "description": "The balance of the loan or capital amount that is considered to be in arrears. Monetary type represented as an integer of cents/pence.",
       "type": "integer",
       "monetary": true
     },


### PR DESCRIPTION
The definition of arrears balance via the properties tab is as follows;

[arrears_balance](https://suade.org/fire/book/documentation/properties/arrears_balance.html#arrears_balance)
The arrears_balance is the difference between the amount of payments contractually due by the borrower minus the amount of the payments actually made by the borrower. Note that this should include [accrued_interest](https://github.com/suadelabs/fire/blob/master/documentation/properties/accrued_interest.md) up to the reporting date.

However, via the schema tab, the definitions is as follows for loan and accounts

The balance of the capital amount that is considered to be in arrears (for overdrafts/credit cards). Monetary type represented as a **naturally positive integer number** of cents/pence.

- Inconsistent as this value could also be a negative
- Also can remove **number** from **integer number** as the word integer already signals a number 
