### PR TITLE
add new purpose  under security schema

### DIFF
--- a/documentation/properties/type.md
+++ b/documentation/properties/type.md
@@ -795,7 +795,7 @@ As defined in [LCR Regulations Article 10 on Liquid Assets][lcr]:
 > include balances receivable on demand at central banks.
 
 ### cb_restricted_reserve
-> Central Bank reserves that are not liquid and not withdrawable.
+> Central Bank reserves that are not liquid and not withdrawable. See Article 7 (2) and Article 10 (1)(b)(iii) of the LCR. (Commission Delegated Regulation (EU) 2015/61 to supplement Regulation (EU) No 575/2013)
 
 ### cash_ratio_deposit
 The [BofE](https://www.bankofengland.co.uk/statistics/notice/2024/statistical-notice-2024-08) defines this as:

--- a/documentation/properties/type.md
+++ b/documentation/properties/type.md
@@ -622,6 +622,7 @@ Other refers to a type of security not covered by the above. If you find yoursel
 ├── bill_of_exchange
 │   └── acceptance
 ├── cb_reserve
+│   └── cb_restricted_reserve
 ├── cb_facility
 ├── cash_ratio_deposit
 ├── cash
@@ -792,6 +793,9 @@ As defined in [LCR Regulations Article 10 on Liquid Assets][lcr]:
 > reserves held by the credit institution in a central bank referred to in points (i) and (ii) provided that the credit institution is permitted to withdraw such reserves at any time during stress periods and the conditions for such withdrawal have been specified in an agreement between the relevant competent authority and the ECB or the central bank;
 
 > include balances receivable on demand at central banks.
+
+### cb_restricted_reserve
+> Central Bank reserves that are not liquid and not withdrawable.
 
 ### cash_ratio_deposit
 The [BofE](https://www.bankofengland.co.uk/statistics/notice/2024/statistical-notice-2024-08) defines this as:

--- a/v1-dev/security.json
+++ b/v1-dev/security.json
@@ -743,6 +743,7 @@
         "cash_ratio_deposit",
         "cb_facility",
         "cb_reserve",
+        "cb_restricted_reserve",
         "cd",
         "cmbs",
         "cmbs_income",


### PR DESCRIPTION
adding new type  "cb_restricted_reserve" under the Security schema for central bank reserves which are not liquid based on Article 7 (2) and not withdrawable and Article 10 (1)(b)(iii) of the Commission Delegated Regulation (EU) 2015/61 to supplement Regulation (EU) No 575/2013.