### PR TITLE
Addition of auto loan children types and auto collateral type

### DIFF
--- a/documentation/properties/type.md
+++ b/documentation/properties/type.md
@@ -439,6 +439,8 @@ Charity serving communities and individuals. Includes non-profit institutions se
 ├── commercial_property
 ├── personal
 ├── auto
+│   ├── new_auto
+│   └── used_auto
 ├── commercial
 ├── credit_card
 │   ├── charge_card
@@ -464,6 +466,12 @@ As outlined in [LCR][lcr] Article 13(2)(g)(iv):
 > agricultural or forestry tractors (see Directive 2003/37/EC)
 > tracked vehicles (see Directive 2007/46/EC)
 > Such loans or leases may include ancillary insurance and service products or additional vehicle parts, and in the case of leases, the residual value of leased vehicles.
+
+### new_auto
+*Needs definition*
+
+### used_auto
+*Needs definition*
 
 ### personal
 As outlined in [LCR][lcr] Article 13(2)(g)(v):
@@ -1165,6 +1173,7 @@ The most common XCS, and that traded in interbank markets, is a mark-to-market (
 ├── life_policy
 ├── cash
 ├── security
+├── auto
 └── other
 ```
 The collateral type defines the form of the collateral, such as property or other assets used to secure an obligation.
@@ -1265,6 +1274,9 @@ From Article 212(2) [CRR](https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CE
 
 ### security
 This identifies that the piece of collateral used is a security, as mapped via the security schema and linked to the collateral schema using the collateral's `security_id` property.
+
+### auto
+*NEEDS Definition*
 
 ### other
 *NEEDS Definition*

--- a/documentation/properties/type.md
+++ b/documentation/properties/type.md
@@ -468,10 +468,10 @@ As outlined in [LCR][lcr] Article 13(2)(g)(iv):
 > Such loans or leases may include ancillary insurance and service products or additional vehicle parts, and in the case of leases, the residual value of leased vehicles.
 
 ### new_auto
-*Needs definition*
+A **new_auto** loan is a type of auto loan provided for the purchase of a brand new vehicle, typically purchased directly from a manufacturer or authorized dealer. The loan is based on the vehicle's full market value at the time of purchase, and the vehicle has no previous owners.
 
 ### used_auto
-*Needs definition*
+A **used_auto** loan is a type of auto loan provided specifically for the purchase of a pre-owned vehicle. It involves financing for vehicles that are not considered new (i.e. have had prior owners). The loan is subject to terms and conditions based on the vehicle’s age, condition, and market value.
 
 ### personal
 As outlined in [LCR][lcr] Article 13(2)(g)(v):
@@ -1276,7 +1276,7 @@ From Article 212(2) [CRR](https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CE
 This identifies that the piece of collateral used is a security, as mapped via the security schema and linked to the collateral schema using the collateral's `security_id` property.
 
 ### auto
-*NEEDS Definition*
+This identifies a motor vehicle (such as an automobile, truck, or other types of vehicles) that is pledged by a borrower as collateral to secure a loan. If the borrower defaults on the loan, the lender has the legal right to seize the vehicle and sell it to recover the outstanding debt.
 
 ### other
 *NEEDS Definition*

--- a/v1-dev/collateral.json
+++ b/v1-dev/collateral.json
@@ -85,6 +85,7 @@
       "description": "The collateral type defines the form of the collateral provided",
       "type": "string",
       "enum": [
+        "auto",
         "cash",
         "commercial_property",
         "commercial_property_hr",

--- a/v1-dev/loan.json
+++ b/v1-dev/loan.json
@@ -614,12 +614,14 @@
         "mortgage",
         "mortgage_charter",
         "multiccy_facility",
+        "new_auto",
         "nostro",
         "other",
         "personal",
         "q_reverse_mortgage",
         "reverse_mortgage",
-        "trade_finance"
+        "trade_finance",
+        "used_auto"
       ]
     },
     "version_id": {


### PR DESCRIPTION
- Addition of the `new_auto` and `used_auto` enums in the loan type schema, which are children of the `auto` loan type
- Addition of the `auto` collateral type