### PR TITLE
fix: add backwards-compatible behaviour for curves with missing type

### DIFF
--- a/schemas/curve.json
+++ b/schemas/curve.json
@@ -74,7 +74,8 @@
   "required": ["id", "date", "values"],
   "additionalProperties": true,
   "if": {
-    "properties": { "type": { "const": "risk_rating" } }
+    "properties": { "type": { "const": "risk_rating" } },
+    "required": ["type"]
   },
   "then": {
     "properties": {

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -324,6 +324,19 @@ class TestCurveSchema:
         }
         self.validator.validate(instance=valid_rate_curve)
 
+    def test_unknown_curve_type(self):
+        # Unknown curve type: numbers are default for backwards compatibility
+        unknown_curve = {
+            "id": "rate_curve_1",
+            "date": "2024-03-20T00:00:00Z",
+            "values": [{"reference": "1m", "value": 0.01}],
+        }
+        self.validator.validate(instance=unknown_curve)
+
+        unknown_curve["values"] = [{"reference": "1m", "value": "AAA"}]
+        with pytest.raises(ValidationError, match="is not of type 'number'"):
+            self.validator.validate(instance=unknown_curve)
+
     def test_invalid_mixed_value_types(self):
         """Test an invalid curve with mixed string and number values"""
         invalid_mixed_curve = {
@@ -336,9 +349,8 @@ class TestCurveSchema:
                 {"reference": "6m", "value": 0.02},
             ],
         }
-        with pytest.raises(ValidationError) as exc_info:
+        with pytest.raises(ValidationError, match="is not of type 'number'"):
             self.validator.validate(instance=invalid_mixed_curve)
-        assert "is not of type 'number'" in str(exc_info.value)
 
 
 class TestBackwardsCompatibility:

--- a/v1-dev/curve.json
+++ b/v1-dev/curve.json
@@ -74,7 +74,8 @@
   "required": ["id", "date", "values"],
   "additionalProperties": true,
   "if": {
-    "properties": { "type": { "const": "risk_rating" } }
+    "properties": { "type": { "const": "risk_rating" } },
+    "required": ["type"]
   },
   "then": {
     "properties": {


### PR DESCRIPTION
Previously, when if curve type was missing the following would be valid:

```json
{"id": "c", "date": "2020-01-01", "values": [{"reference": "1m", "value": 0.1}]}
```

however with https://github.com/SuadeLabs/fire/pull/411 this behaviour changed. This MR restores the original behaviour when curve type is missing.