### PR TITLE
add new iso currency codes

### DIFF
--- a/documentation/properties/currency_code.md
+++ b/documentation/properties/currency_code.md
@@ -12,6 +12,8 @@ The **currency_code** represents the currency of the data object and all the rel
 
 Currencies are represented as 3-letter codes in accordance with [ISO 4217][iso4217] standards.
 
+The following currency codes are deprecated and will be removed from Jan 2026: ANG, CUC, HRK, SLL, USS, ZWL.
+
 ---
 
 [acc]: https://github.com/suadelabs/fire/blob/master/documentation/properties/accrued_interest.md

--- a/schemas/common.json
+++ b/schemas/common.json
@@ -589,6 +589,7 @@
       "SEK",
       "SGD",
       "SHP",
+      "SLE",
       "SLL",
       "SOS",
       "SRD",
@@ -614,10 +615,12 @@
       "UYU",
       "UYW",
       "UZS",
+      "VED",
       "VES",
       "VND",
       "VUV",
       "WST",
+      "XAD",
       "XAF",
       "XAG",
       "XAU",
@@ -626,6 +629,7 @@
       "XBC",
       "XBD",
       "XCD",
+      "XCG",
       "XDR",
       "XOF",
       "XPD",
@@ -637,7 +641,8 @@
       "XXX",
       "YER",
       "ZAR",
-      "ZMW"
+      "ZMW",
+      "ZWG"
     ]
   },
   "day_count_convention": {

--- a/v1-dev/common.json
+++ b/v1-dev/common.json
@@ -589,6 +589,7 @@
       "SEK",
       "SGD",
       "SHP",
+      "SLE",
       "SLL",
       "SOS",
       "SRD",
@@ -614,10 +615,12 @@
       "UYU",
       "UYW",
       "UZS",
+      "VED",
       "VES",
       "VND",
       "VUV",
       "WST",
+      "XAD",
       "XAF",
       "XAG",
       "XAU",
@@ -626,6 +629,7 @@
       "XBC",
       "XBD",
       "XCD",
+      "XCG",
       "XDR",
       "XOF",
       "XPD",
@@ -637,7 +641,8 @@
       "XXX",
       "YER",
       "ZAR",
-      "ZMW"
+      "ZMW",
+      "ZWG"
     ]
   },
   "day_count_convention": {


### PR DESCRIPTION
Updates ISO currencies to add recent additions: SLE, VED, XAD, XCG, ZWG

Also deprecates the following legacy codes: ANG, CUC, HRK, SLL, USS, ZWL . A separate PR to remove deprecated currency codes will be merged in Jan 2026.