### PR TITLE
docs: 📝 enhance sic_code and minority_interest descriptions

### DIFF
--- a/documentation/properties/sic_code.md
+++ b/documentation/properties/sic_code.md
@@ -8,10 +8,16 @@ schemas:	[customer, issuer, guarantor]
 
 ---
 
-The United Kingdom [**Standard Industrial Classification of Economic Activities**][siccode2007] (SIC) is used to classify business establishments and other standard units by the type of economic activity in which they are engaged. The new version of these codes (SIC 2007) was adopted by the UK as from 1st January 2008.
+The **Standard Industrial Classification (SIC)** is a system used to classify business establishments and other standard units by the type of economic activity in which they are engaged. The appropriate SIC reference depends on jurisdiction:
 
-The classification provides a framework for the collection, tabulation, presentation and analysis of data, and its use promotes uniformity.
+- **United Kingdom:** For UK-domiciled entities, the applicable reference is the [UK SIC classification][siccode2007] published by the Office for National Statistics. The current version of these codes (SIC 2007) has been in effect since 1 January 2008.
 
-In addition, it can be used for administrative purposes and by non-government bodies as a convenient way of classifying industrial activities into a common structure.
+- **United States:** For US-domiciled entities, the applicable reference is the [SIC code list][sec_sic] maintained by the U.S. Securities and Exchange Commission.
+
+The classification provides a consistent framework for the collection, tabulation, presentation and analysis of economic activity.
+
+---
 
 [siccode2007]: http://www.ons.gov.uk/methodology/classificationsandstandards/ukstandardindustrialclassificationofeconomicactivities/uksic2007
+
+[sec_sic]: https://www.sec.gov/search-filings/standard-industrial-classification-sic-code-list

--- a/extensions/documentation/properties/minority_interest.md
+++ b/extensions/documentation/properties/minority_interest.md
@@ -1,1 +1,17 @@
- 
+---
+layout:     property
+title:      "minority_interest"
+schemas:    [customer]
+---
+
+# minority_interest
+
+---
+
+The interest of shareholders who, in the aggregate, own less than half the shares in a corporation. On the consolidated balance sheets of companies whose subsidiaries are not wholly owned, the minority interest is shown as a separate equity account or as a liability of indefinite term.
+
+Refer to [FR Y-14Q][FR_Y-14Q] for more information.
+
+---
+
+[FR_Y-14Q]: https://www.federalreserve.gov/apps/reportingforms/Report/Index/FR_Y-14Q

--- a/schemas/entity.json
+++ b/schemas/entity.json
@@ -1124,7 +1124,7 @@
       ]
     },
     "sic_code": {
-      "description": "The UK SIC 2007 standard industry and sector classification.",
+      "description": "Standard Industrial Classification (SIC) system. The applicable reference depends on jurisdiction.",
       "type": "integer",
       "minimum": 0,
       "maximum": 99999

--- a/v1-dev/entity.json
+++ b/v1-dev/entity.json
@@ -1110,7 +1110,7 @@
       ]
     },
     "sic_code": {
-      "description": "The UK SIC 2007 standard industry and sector classification.",
+      "description": "Standard Industrial Classification (SIC) system. The applicable reference depends on jurisdiction.",
       "type": "integer",
       "minimum": 0,
       "maximum": 99999


### PR DESCRIPTION
Enhanced the `sic_code` description to reflect jurisdictional applicability across [UK SIC 2007](http://www.ons.gov.uk/methodology/classificationsandstandards/ukstandardindustrialclassificationofeconomicactivities/uksic2007) and the SEC [SIC code list](https://www.sec.gov/search-filings/standard-industrial-classification-sic-code-list) for US-based firms. Added a description for `minority_interest` in alignment with the field’s definition in the customer schema.