### PR TITLE
feat(account & loan schemas): :sparkles: added `min_interest_repaymen…

### DIFF
--- a/documentation/properties/min_interest_repayment.md
+++ b/documentation/properties/min_interest_repayment.md
@@ -1,0 +1,13 @@
+---
+layout:     property
+title:      "min_interest_repayment"
+schemas:    [account, loan]
+---
+
+# min_interest_repayment
+
+---
+
+The minimum interest on outstanding balance and fees that customers are due to repay within the next 30 days.
+
+---

--- a/documentation/properties/min_principal_repayment.md
+++ b/documentation/properties/min_principal_repayment.md
@@ -1,0 +1,13 @@
+---
+layout:     property
+title:      "min_principal_repayment"
+schemas:    [account, loan]
+---
+
+# min_principal_repayment
+
+---
+
+The minimum principal balance that customers are due to repay within the next 30 days.
+
+---

--- a/schemas/account.json
+++ b/schemas/account.json
@@ -337,6 +337,16 @@
       "type": "integer",
       "monetary": true
     },
+    "min_interest_repayment": {
+      "description": "The minimum interest on outstanding balance and fees that customers are due to repay within the next 30 days.",
+      "type": "integer",
+      "monetary": true
+    },
+    "min_principal_repayment": {
+      "description": "The minimum principal balance that customers are due to repay within the next 30 days.",
+      "type": "integer",
+      "monetary": true
+    },
     "minimum_balance": {
       "description": "Indicates the minimum balance of each account within the aggregate. Monetary type represented as a naturally positive integer number of cents/pence.",
       "type": "integer",

--- a/schemas/loan.json
+++ b/schemas/loan.json
@@ -458,6 +458,16 @@
       "minimum": 0,
       "monetary": true
     },
+    "min_interest_repayment": {
+      "description": "The minimum interest on outstanding balance and fees that customers are due to repay within the next 30 days.",
+      "type": "integer",
+      "monetary": true
+    },
+    "min_principal_repayment": {
+      "description": "The minimum principal balance that customers are due to repay within the next 30 days.",
+      "type": "integer",
+      "monetary": true
+    },
     "minimum_balance": {
       "description": "Indicates the minimum balance of each loan within the aggregate.",
       "type": "integer",


### PR DESCRIPTION
Two new enums added to the Account and Loan schemas:
1. min_principal_repayment: The minimum principal balance that customers are due to repay within the next 30 days
2. min_interest_repayment: The minimum interest on outstanding balance and fees that customers are due to repay within the next 30 days
