### PR TITLE
feat: ✨ Add collateral.type enums and update loan.recourse from boolean to string type with enum values

### DIFF
--- a/documentation/properties/type.md
+++ b/documentation/properties/type.md
@@ -1547,6 +1547,12 @@ The most common XCS, and that traded in interbank markets, is a mark-to-market (
 │   └── res_property_hr
 ├── farm
 ├── commercial_property
+│   ├── healthcare
+│   ├── hospitality
+│   ├── industrial
+│   ├── office
+│   ├── retail
+│   ├── warehouse
 │   └── commercial_property_hr
 ├── immovable_property
 ├── guarantee
@@ -1688,6 +1694,30 @@ As per Article 124 (3) of CRR 575/2013: In order to be eligible for the treatmen
 (d) all the information required at origination of the exposure and for monitoring purposes is properly documented, including information on the ability of the obligor to repay and on the valuation of the property;
 (e) the requirements set out in Article 208 are met and the valuation rules set out in Article 229(1) are complied with.
 For the purposes of point (c), institutions may exclude situations where purely macro-economic factors affect both the value of the property and the performance of the obligor.
+
+### healthcare
+
+Property used for medical or health-related services, including hospitals, medical campuses, assisted-living facilities, memory care facilities, and skilled-nursing or long-term care homes.
+
+### hospitality
+
+Property providing short-term accommodation or leisure services, including hotels, resorts, and gaming or entertainment facilities.
+
+### industrial
+
+Property used for manufacturing, assembly, research and development, or light industrial activities. Excludes properties primarily used for warehousing or logistics.
+
+### office
+
+Property used for administrative, professional, or medical office purposes.
+
+### retail
+
+Property used for the sale of goods or services to the public, including shopping centers, malls, high-street retail, and standalone stores.
+
+### warehouse
+
+Property used for storage, logistics, or distribution of goods.
 
 ### multifamily
 

--- a/extensions/documentation/properties/recourse.md
+++ b/extensions/documentation/properties/recourse.md
@@ -12,4 +12,22 @@ Whether there is recourse on a loan. Recourse on a loan refers to terms in the m
 
 For additional details refer to: https://www.federalreserve.gov/apps/reportingforms/Report/Index/FR_Y-14M
 
+```bash
+├── full
+├── partial
+└── none
+```
+
+### full
+
+The lender has full recourse to the borrower. If the borrower defaults, the lender may pursue recovery for the entire outstanding debt beyond the value of the collateral.
+
+### partial
+
+The lender has limited recourse to the borrower. If the borrower defaults, the lender may pursue recovery for only a portion of the outstanding debt beyond the value of the collateral.
+
+### none
+
+The lender has no recourse to the borrower. If the borrower defaults, recovery is limited to the value of the collateral.
+
 --- 

--- a/extensions/schemas/loan.json
+++ b/extensions/schemas/loan.json
@@ -753,7 +753,12 @@
     },
     "recourse": {
       "description": "Whether there is recourse on a loan. Recourse on a loan refers to terms in the mortgage contract that give the owner of the note the right to pursue additional claims against the borrower beyond possession of the property. Refer to https://www.federalreserve.gov/apps/reportingforms/Report/Index/FR_Y-14M for more information.",
-      "type": "boolean",
+      "type": "string",
+      "enum": [
+        "full",
+        "none",
+        "partial"
+      ],
       "jurisdictions": [
         "US"
       ]

--- a/schemas/collateral.json
+++ b/schemas/collateral.json
@@ -119,17 +119,22 @@
         "farm",
         "four_units",
         "guarantee",
+        "healthcare",
+        "hospitality",
         "immovable_property",
+        "industrial",
         "life_policy",
         "luxury",
         "manufactured_house",
         "multifamily",
+        "office",
         "one_unit",
         "other",
         "planned_unit_dev",
         "res_property_hr",
         "resi_mixed_use",
         "residential_property",
+        "retail",
         "security",
         "single_family",
         "sport",
@@ -138,7 +143,8 @@
         "townhouse",
         "truck",
         "two_units",
-        "van"
+        "van",
+        "warehouse"
       ]
     },
     "value": {

--- a/v1-dev/collateral.json
+++ b/v1-dev/collateral.json
@@ -114,17 +114,22 @@
         "farm",
         "four_units",
         "guarantee",
+        "healthcare",
+        "hospitality",
         "immovable_property",
+        "industrial",
         "life_policy",
         "luxury",
         "manufactured_house",
         "multifamily",
+        "office",
         "one_unit",
         "other",
         "planned_unit_dev",
         "res_property_hr",
         "resi_mixed_use",
         "residential_property",
+        "retail",
         "security",
         "single_family",
         "sport",
@@ -133,7 +138,8 @@
         "townhouse",
         "truck",
         "two_units",
-        "van"
+        "van",
+        "warehouse"
       ]
     },
     "value": {


### PR DESCRIPTION
This update adds new enums for collateral.type and loan.recourse as described below:

### Collateral Schema
1. collateral.type
   - Add `commercial_property` child enums `healthcare`, `hospitality`, `industrial`, `office`, `retail`, `warehouse`

### Loan Extension Schema
2. loan.recourse (update field type and add enums)
   - Update field type from boolean → string with enumerated values
   - Add enums `full`, `partial`, `none`
   - Map previous values: TRUE → full, FALSE → none