### PR TITLE
feat: ✨ Add valuation_type and orig_valuation_type enums, and occupancy_rate field on the collateral ext schema

### DIFF
--- a/extensions/documentation/properties/occupancy_rate.md
+++ b/extensions/documentation/properties/occupancy_rate.md
@@ -1,0 +1,17 @@
+---
+layout:     property
+title:      "occupancy_rate"
+schemas:    [loan]
+---
+
+# occupancy_rate
+
+---
+
+The current physical occupancy of rent-paying tenants, expressed as a percentage of the property's net rentable area. This represents the proportion of space that is presently leased and occupied as of the reporting date.
+
+Report as a decimal fraction (e.g., 0.80 = 80%).
+
+For additional details refer to: https://www.federalreserve.gov/apps/reportingforms/Report/Index/FR_Y-14Q
+
+--- 

--- a/extensions/documentation/properties/valuation_type.md
+++ b/extensions/documentation/properties/valuation_type.md
@@ -20,9 +20,25 @@ For more information, refer to:
 ├── desktop
 ├── full
 ├── limited
+├── prospective_market_value
+│   ├── as_completed
+│   ├── as_is
+│   └── as_stabilized
 ├── purchase_price
 └── tav
 ```
+
+### as_completed
+
+The prospective market value of the property as of the date construction or renovation is expected to be completed, assuming all proposed improvements are finished according to the plans and specifications.
+
+### as_is
+
+The prospective market value of the property in its actual physical condition, use, and zoning as of the appraisal’s effective date, reflecting any deductions or discounts for incomplete construction, non-market leases, or other existing conditions.
+
+### as_stabilized
+
+The prospective market value of the property as of the date it is projected to achieve stabilized occupancy, representing the point when the property reaches typical market-level performance after lease-up or renovation.
 
 ### auto_val_model
 Automated Valuation Model (AVM) - A computer-driven mathematical model that uses property characteristics, location, and market conditions to determine property values without a physical inspection.
@@ -38,6 +54,10 @@ Full Appraisal - A comprehensive property valuation that includes a physical ins
 
 ### limited
 Limited Appraisal - A property valuation that includes a physical inspection but may have a more limited scope than a full appraisal, often focusing on specific aspects of the property.
+
+### prospective_market_value
+
+Prospective Market Value - A valuation provided by an appraiser for a property interest related to a credit decision for a proposed development or renovation project, based on the condition of the property at a specified stage of its development or renovation.
 
 ### purchase_price
 Purchase Price - The actual price paid for the property in a recent transaction, used as the basis for valuation.

--- a/extensions/schemas/collateral.json
+++ b/extensions/schemas/collateral.json
@@ -45,11 +45,15 @@
       "description": "Methodology used in the determination of the collateral value. Refer to https://www.ecfr.gov/current/title-12/chapter-VI/subchapter-B/part-614/subpart-F/section-614.4265 and https://www.federalreserve.gov/boarddocs/srletters/2010/sr1016a1.pdf",
       "type": "string",
       "enum": [
+        "as_completed",
+        "as_is",
+        "as_stabilized",
         "auto_val_model",
         "broker_price",
         "desktop",
         "full",
         "limited",
+        "prospective_market_value",
         "purchase_price",
         "tav"
       ],

--- a/extensions/schemas/loan.json
+++ b/extensions/schemas/loan.json
@@ -409,6 +409,14 @@
         "US"
       ]
     },
+    "occupancy_rate": {
+      "type": "string",
+      "format": "number",
+      "description": "The current physical occupancy of rent-paying tenants, expressed as a percentage of the property's net rentable area. This represents the proportion of space that is presently leased and occupied as of the reporting date. Refer to https://www.federalreserve.gov/apps/reportingforms/Report/Index/FR_Y-14Q for more information.",
+      "jurisdictions": [
+        "US"
+      ]
+    },
     "orig_base_rate": {
       "description": "The base rate at origination.",
       "type": "string",


### PR DESCRIPTION
This update adds new enums for collateral.valuation_type and collateral.orig_valuation_type, and a collateral.occupancy_rate field on the collateral extension schema, as described below:

### Collateral Extension Schema

1. collateral.valuation_type 
   - Add parent enum `prospective_market_value`
   - Add `prospective_market_value` child enums `as_is`, `as_stabilized`, `as_completed`

2. collateral.orig_valuation_type
   - Add parent enum `prospective_market_value`
   - Add `prospective_market_value` child enums `as_is`, `as_stabilized`, `as_completed`

3. collateral.occupancy_rate
   - Represents the current physical occupancy of rent-paying tenants, expressed as a percentage of the property's net rentable area.