### PR TITLE
feat: update currency_code to be optional

### DIFF
--- a/documentation/properties/contribution_amount.md
+++ b/documentation/properties/contribution_amount.md
@@ -8,5 +8,4 @@ schemas:    [adjustment]
 
 ---
 
-The **contribution_amount** reflects the amount that the adjustment contributes to to the reportable value (in a report/cell). This amount is a monetary amount in minor currency of the corresponding currency_code for the adjustment. Implementation of contributions may differ, but are typically  additive so that multiple contributions can be aggregated.
-
+The **contribution_amount** reflects the amount that the adjustment contributes to to the reportable value (in a report/cell). If a currency_code is present, this amount is taken to be monetary in minor currency of the corresponding currency. If no currency code is present, this amount is taken as-is and assumed to be non-monetary (e.g. a percentage or risk weight). Implementation of contributions may differ, but are typically  additive so that multiple contributions can be aggregated.

--- a/documentation/properties/contribution_text.md
+++ b/documentation/properties/contribution_text.md
@@ -8,6 +8,4 @@ schemas:    [adjustment]
 
 ---
 
-The **contribution_text** is used where contributions are not monetary values, but rather text/string values or decimals/percentages. As these values are typically used in reporting in a one-to-one correspondence, aggregations of contribution texts typically don't make sense. Implementation specific cases may also be present to account for the wider range of non-monetary reportable values.
-
-
+The **contribution_text** is used where contributions are not numbers, but rather text/string values. As these values are typically used in reporting in a one-to-one correspondence, aggregations of contribution texts typically don't make sense.

--- a/schemas/adjustment.json
+++ b/schemas/adjustment.json
@@ -22,9 +22,8 @@
       "type": "string"
     },
     "contribution_amount": {
-      "description": "The contribution amount this adjustment should make to the specified report cell. A positive/negative number in minor units (cents/pence).",
-      "type": "integer",
-      "monetary": true
+      "description": "The contribution amount this adjustment should make to the specified report cell. A positive/negative number, which if representing a monetary amount (i.e. accompanied by a currency code) is in minor units (cents/pence).",
+      "type": "number"
     },
     "contribution_text": {
       "description": "The text to use for the adjustment where the reported cell is not a monetary value.",
@@ -63,8 +62,5 @@
     {"required": ["id", "date", "report_type", "row", "col", "contribution_amount"]},
     {"required": ["id", "date", "report_type", "row", "col", "contribution_text"]}
   ],
-  "dependencies": {
-    "contribution_amount": ["currency_code"]
-  },
   "additionalProperties": true
 }


### PR DESCRIPTION
Draft: this allows explicitly setting a quantity (e.g. a rate) as a dimenensionless number by not providing a currency_code

Previously we have insisted every contribution_amount be accompanied by a currency to avoid it being accidentally omitted.

However, this lead to a situation where people started placing non-monetary floats into the text field in order to avoid currency conversion. This in turn caused issues with ids that look like numbers: 1234E5432, 0001000 etc.

## examples

```js
// 1.23 USD
{contribution_amount: 123, currency_code: "GBP"}
// 1.23 literal (no unit)
{contribution_amount: 1.23}
// "1.23" (literal string / id)
{contribution_text: "1.23"}
```

## anything else?

this change requires updating the amount field from integer to float - we may want a way to further validate the int status of monetary values

we may want to explicitly version this change as it means we will explicitly prohibit the use of contribution_text for numbers