### PR TITLE
Add New AnaCredit Attributes to FIRE for Original Protection Value

### DIFF
--- a/documentation/properties/orig_mtm.md
+++ b/documentation/properties/orig_mtm.md
@@ -1,0 +1,15 @@
+---
+layout:     property
+title:      "orig_mtm"
+schemas:    [security]
+---
+
+# orig_mtm
+
+---
+
+The **orig_mtm** is the mark-to-market value of the security at the origination of the transaction. It identifies the original protection value that was established at the date when the protection item was originally received as a credit protection
+
+---
+
+Reference: [AnaCredit Reporting Manual Part II , Section 9.4.9, Original protection value](<https://www.ecb.europa.eu/pub/pdf/other/AnaCredit_Manual_Part_II_Datasets_and_data_attributes_201905~cc9f4ded23.en.pdf>)

--- a/documentation/properties/orig_mtm_eur.md
+++ b/documentation/properties/orig_mtm_eur.md
@@ -1,0 +1,17 @@
+---
+layout:     property
+title:      "orig_mtm_eur"
+schemas:    [security]
+---
+
+# orig_mtm_eur
+
+---
+
+The **orig_mtm_eur** is the mark-to-market value of the security in **euro** at the origination of the transaction. It identifies the original protection value that was established at the date when the protection item was originally received as a credit protection
+
+In the context of AnaCredit, the original protection value is a monetary amount in euro. **The original protection value will remain unchanged** throughout the entire life of the instrument.
+
+---
+
+Reference: [AnaCredit Reporting Manual Part II , Section 9.4.9, Original protection value](<https://www.ecb.europa.eu/pub/pdf/other/AnaCredit_Manual_Part_II_Datasets_and_data_attributes_201905~cc9f4ded23.en.pdf>)

--- a/documentation/properties/orig_value_eur.md
+++ b/documentation/properties/orig_value_eur.md
@@ -1,0 +1,17 @@
+---
+layout:     property
+title:      "orig_value_eur"
+schemas:    [collateral]
+---
+
+# orig_value_eur
+
+---
+
+The **orig_value_eur** is the valuation as used by the bank for the collateral in **euro** at the origination of the related loan or line of credit.
+
+In the context of AnaCredit, the original protection value is a monetary amount in euro. **The original protection value will remain unchanged** throughout the entire life of the instrument.
+
+---
+
+Reference: [AnaCredit Reporting Manual Part II , Section 9.4.9, Original protection value](<https://www.ecb.europa.eu/pub/pdf/other/AnaCredit_Manual_Part_II_Datasets_and_data_attributes_201905~cc9f4ded23.en.pdf>)

--- a/schemas/collateral.json
+++ b/schemas/collateral.json
@@ -82,6 +82,11 @@
       "type": "integer",
       "monetary": true
     },
+    "orig_value_eur": {
+      "description": "The valuation as used by the bank for the collateral in euro at the origination of the related loan or line of credit. Monetary type represented as a naturally positive integer number of cents/pence.",
+      "type": "integer",
+      "monetary": true
+    },
     "owner_id": {
       "description": "identifies the provider of the collateral, including cases where the collateral is provided by a third party.",
       "type": "string"

--- a/schemas/security.json
+++ b/schemas/security.json
@@ -667,6 +667,16 @@
       "type": "integer",
       "monetary": true 
     },
+    "orig_mtm": {
+      "description": "is the mark-to-market value of the security at the origination of the transaction. Monetary number of cents/pence.",
+      "type": "integer",
+      "monetary": true
+    },
+    "orig_mtm_eur": {
+      "description": "is the mark-to-market value of the security in euro at the origination of the transaction. Monetary number of cents/pence.",
+      "type": "integer",
+      "monetary": true
+    },
     "orig_rate_type": {
       "description": "The rate_type at origination.",
       "type": "string",


### PR DESCRIPTION
Added three new attributes to identify the original protection value of a protection item mapped on the Collateral or Security Schemas