### PR TITLE
Added status_date Field to AnaCredit Account Schema

### DIFF
--- a/documentation/properties/status_date.md
+++ b/documentation/properties/status_date.md
@@ -1,7 +1,7 @@
 ---
 layout:		property
 title:		"status_date"
-schemas:	[loan, security]
+schemas:	[account, loan, security]
 ---
 
 # status_date

--- a/schemas/account.json
+++ b/schemas/account.json
@@ -885,6 +885,11 @@
         "unaudited"
       ]
     },
+        "status_date": {
+      "description": "Provides the date on which status changed.",
+      "type": "string",
+      "format": "date-time"
+    },
     "trade_date": {
       "description": "The timestamp that the trade or financial product terms are agreed. YYYY-MM-DDTHH:MM:SSZ in accordance with ISO 8601.",
       "type": "string",


### PR DESCRIPTION
Add status_date to the AnaCredit Account schema to capture the date an instrument transitions from non-performing to performing status