### PR TITLE
Add Enum fsc to national_id_type

### DIFF
--- a/documentation/properties/national_id_type.md
+++ b/documentation/properties/national_id_type.md
@@ -14,4 +14,4 @@ Reference: [AnaCredit Reporting Manual Part II, section 12.4.3](<https://www.ecb
 
 Reference: [ECB Website](<https://www.ecb.europa.eu/stats/ecb_statistics/anacredit/html/index.en.html>)
 
-Reference: [List of national identifiers](<https://www.ecb.europa.eu/stats/money/aggregates/anacredit/shared/pdf/List_of_national_identifiers.en.xlsx>)
+Reference: [List of national identifiers](<https://www.ecb.europa.eu/stats/money/aggregates/anacredit/shared/pdf/List_of_national_identifiers_ver_3_6.xlsx>)

--- a/schemas/entity.json
+++ b/schemas/entity.json
@@ -2517,6 +2517,7 @@
         "fl",
         "fon",
         "fsa",
+        "fsc",
         "fsr",
         "ft",
         "gem",


### PR DESCRIPTION
added enum `fsc` to national_id_type following AnaCredit's recent change to [national identifiers](https://www.ecb.europa.eu/stats/ecb_statistics/anacredit/html/index.es.html#:~:text=List%20of%20national%20identifiers) 

