### PR TITLE
fix: correct two typos in schema and documentation descriptions

### DIFF
--- a/documentation/properties/gross_purchase_eur.md
+++ b/documentation/properties/gross_purchase_eur.md
@@ -8,5 +8,5 @@ schemas:    [security]
 
 ---
 
-The market value of purcahses at the time of purchase in EUR
+The market value of purchases at the time of purchase in EUR
 For additional details refer to: https://www.centralbank.ie/statistics/statistical-reporting-requirements/credit-institutions/survey-of-credit-institutions-return-crs2

--- a/extensions/documentation/properties/mod_date.md
+++ b/extensions/documentation/properties/mod_date.md
@@ -8,7 +8,7 @@ schemas:    [loan]
 
 ---
 
-The date on which any modifications were made to renew or change contract terms of the loan and the borrower meets BHC or IHC or SLHC current credit standards (not under an arrears arrangment).
+The date on which any modifications were made to renew or change contract terms of the loan and the borrower meets BHC or IHC or SLHC current credit standards (not under an arrears arrangement).
 
 For additional details refer to: https://www.federalreserve.gov/apps/reportingforms/Report/Index/FR_Y-14M
 

--- a/extensions/schemas/loan.json
+++ b/extensions/schemas/loan.json
@@ -285,7 +285,7 @@
     "mod_date": {
       "type": "string",
       "format": "date-time",
-      "description": "The date on which any modifications were made to renew or change contract terms of the loan and the borrower meets BHC or IHC or SLHC current credit standards (not under an arrears arrangment). Refer to https://www.federalreserve.gov/apps/reportingforms/Report/Index/FR_Y-14M for more information.",
+      "description": "The date on which any modifications were made to renew or change contract terms of the loan and the borrower meets BHC or IHC or SLHC current credit standards (not under an arrears arrangement). Refer to https://www.federalreserve.gov/apps/reportingforms/Report/Index/FR_Y-14M for more information.",
       "jurisdictions": [
         "US"
       ]

--- a/schemas/security.json
+++ b/schemas/security.json
@@ -423,7 +423,7 @@
       "maximum": 3
     },
     "gross_purchase_eur": {
-      "description": "The market value of purcahses at the time of purchase in EUR.",
+      "description": "The market value of purchases at the time of purchase in EUR.",
       "type": "integer",
       "monetary": true
     },


### PR DESCRIPTION
Corrects two spelling mistakes in description text. Each appears twice: once in the schema
and once in the corresponding documentation page.

| File | Line | Was | Now |
| --- | --- | --- | --- |
| `schemas/security.json` | 426 | `purcahses` | `purchases` |
| `documentation/properties/gross_purchase_eur.md` | 11 | `purcahses` | `purchases` |
| `extensions/schemas/loan.json` | 288 | `arrangment` | `arrangement` |
| `extensions/documentation/properties/mod_date.md` | 11 | `arrangment` | `arrangement` |

The schema occurrences are the `description` of `gross_purchase_eur` (security) and `mod_date`
(loan extension).

Only description text is changed. No property name, enum value, type, or any other schema
key is touched, so the wire contract is unchanged. Both misspellings were checked against
every JSON key and every enum value in `schemas/` and `extensions/schemas/` first, and appear
in neither.

Both edited JSON files still parse. `pytest --ignore=tests/test_extensions.py` gives
231 passed, 2 skipped; `tests/test_extensions.py` was not run because `iso3166` is not
available in this environment.
