### PR TITLE
fix: correct spelling in documentation and one schema description

### DIFF
--- a/documentation/properties/impairment_status.md
+++ b/documentation/properties/impairment_status.md
@@ -49,7 +49,7 @@ Further reading:
 * [HKMA Loan classification system][hkma-lcs]
 * [MAS 612][mas612]
 
-Some agencies may also refer to *classified* loans as those that fall in substandard, doubtful and loss categories (occassionally watch/special mention as well).
+Some agencies may also refer to *classified* loans as those that fall in substandard, doubtful and loss categories (occasionally watch/special mention as well).
 
 ### performing
 

--- a/documentation/properties/leg_type.md
+++ b/documentation/properties/leg_type.md
@@ -5,7 +5,7 @@ schemas:    [derivative]
 ---
 
 # leg_type
-Payoff type of a derivative leg, which may be a stand-alone trade (e.g. fra, cap), or part of an instrument refered to in the derivative_type attibute (eg. vanilla_swap). The atribute is an enum with the following members:
+Payoff type of a derivative leg, which may be a stand-alone trade (e.g. fra, cap), or part of an instrument referred to in the derivative_type attribute (eg. vanilla_swap). The attribute is an enum with the following members:
 
 ### fixed
 the leg cash flows are fixed amounts

--- a/documentation/properties/third_party_risk_transfer.md
+++ b/documentation/properties/third_party_risk_transfer.md
@@ -5,7 +5,7 @@ schemas:	[security]
 ---
 
 # third_party_risk_transfer
-Risk transfer claimed by a securitisation Originator, measured as the Expected loss (EL) + the Unexpected loss (UL) of the underlying **securitised assets** transfered to third parties, expressed as a percentage of the EL + UL of the total **securitised assets**. For an originator reporting under SA, EL shall be the specific credit risk adjustment of the securitised assets and the UL shall be the capital requirement of the securitised assets. 
+Risk transfer claimed by a securitisation Originator, measured as the Expected loss (EL) + the Unexpected loss (UL) of the underlying **securitised assets** transferred to third parties, expressed as a percentage of the EL + UL of the total **securitised assets**. For an originator reporting under SA, EL shall be the specific credit risk adjustment of the securitised assets and the UL shall be the capital requirement of the securitised assets. 
 
 
 ---

--- a/documentation/properties/type.md
+++ b/documentation/properties/type.md
@@ -277,7 +277,7 @@ A **regional government** is a government entity that only has control on a spec
 
 ### central_govt
 
-A **central government** is the government of a nation-state. While some countries may have **regional governments** that operate autonomously, the **central goverment** is the governing system that is concerned with issues that affect the entire nation.
+A **central government** is the government of a nation-state. While some countries may have **regional governments** that operate autonomously, the **central government** is the governing system that is concerned with issues that affect the entire nation.
 
 ### local_authority
 
@@ -502,7 +502,7 @@ The [FCA Handbook](https://www.handbook.fca.org.uk/handbook/glossary/G569.html?d
 
 ### financial_holding
 
-A financial holding copmany is defined by the EU [here][lcr] Article 4(1)(20):
+A financial holding company is defined by the EU [here][lcr] Article 4(1)(20):
 
 > (20) 'financial holding company' means a financial institution, the subsidiaries of which are exclusively or mainly institutions or financial institutions, at least one of such subsidiaries being an institution, and which is not a mixed financial holding company;
 
@@ -518,7 +518,7 @@ Any other type to be classified as financial but not one of the other types witi
 
 ### pic
 
-A financial holding copmany is defined by the EU [here](http://eur-lex.europa.eu/eli/reg_del/2015/61/oj) Article 3:
+A financial holding company is defined by the EU [here](http://eur-lex.europa.eu/eli/reg_del/2015/61/oj) Article 3:
 
 > 'personal investment company' ('PIC') means an undertaking or a trust whose owner or beneficial owner, respectively, is a natural person or a group of closely related natural persons, which was set up with the sole purpose of managing the wealth of the owners and which does not carry out any other commercial, industrial or professional activity. The purpose of the PIC may include other ancillary activities such as segregating the owners' assets from corporate assets, facilitating the transmission of assets within a family or preventing a split of the assets after the death of a member of the family, provided these are connected to the main purpose of managing the owners' wealth;
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -221,7 +221,7 @@ Long EURCAD spot (100 EUR for 140 CAD spot trade)
 {{#include fx_spot.json:5:}}
 ```
 #### FX swap
-Short 1-year AUDUSD fx swap. The notional amounts are used to calculate the spot rate (occuring on the start date).
+Short 1-year AUDUSD fx swap. The notional amounts are used to calculate the spot rate (occurring on the start date).
 ```json
 {{#include fx_swap.json:5:}}
 ```

--- a/schemas/security.json
+++ b/schemas/security.json
@@ -1140,7 +1140,7 @@
       "minimum": 0.0
     },
     "third_party_risk_transfer":{
-      "description": "Attribute used for a securitisation transaction. Percentage of the securitised assets expected and unexpected losses transfered to 3rd parties.",
+      "description": "Attribute used for a securitisation transaction. Percentage of the securitised assets expected and unexpected losses transferred to 3rd parties.",
       "type": "number"
     },
     "trade_date": {


### PR DESCRIPTION
Spelling corrections in documentation prose and one schema description. Separate from #682,
which covers a different set of lines.

| File | Line | Was | Now |
| --- | --- | --- | --- |
| `documentation/properties/type.md` | 280 | `central goverment` | `central government` |
| `documentation/properties/type.md` | 505 | `financial holding copmany` | `financial holding company` |
| `documentation/properties/type.md` | 521 | `financial holding copmany` | `financial holding company` |
| `documentation/properties/leg_type.md` | 8 | `refered`, `attibute`, `atribute` | `referred`, `attribute`, `attribute` |
| `documentation/properties/impairment_status.md` | 52 | `occassionally` | `occasionally` |
| `documentation/properties/third_party_risk_transfer.md` | 8 | `transfered` | `transferred` |
| `examples/README.md` | 224 | `occuring` | `occurring` |
| `schemas/security.json` | 1143 | `transfered` | `transferred` |

The schema change is the `description` of `third_party_risk_transfer`. No property name, enum
value or type is touched; `transfered` was checked against every JSON key and enum value in
`schemas/security.json` and appears in neither.

Two further misspellings were left alone because they sit inside block quotes of external
source text: `type.md:501` (`dependants`, quoting the Regulated Activities Order, where the
British noun spelling is also correct) and `type.md:2170` (`recieved`, quoting the Bank of
England MLAR notes). Correcting a quotation would make it diverge from the cited source.

`schemas/security.json` still parses. `pytest --ignore=tests/test_extensions.py` gives
231 passed, 2 skipped; `tests/test_extensions.py` was not run because `iso3166` is not
available in this environment.
