### PR TITLE
feat: add fire-mcp server for mapping data onto the FIRE standard

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -8,6 +8,9 @@ on:
       - master
       - '*'
 
+permissions:
+  contents: read
+
 jobs:
   test_on_python_version:
     runs-on: ubuntu-24.04

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -39,4 +39,23 @@ jobs:
 
       - name: Test with pytest
         run: |
-          pytest -v
+          pytest tests -v
+
+  test_fire_mcp:
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install fire_mcp
+        run: |
+          pip install -e "fire_mcp/[dev]"
+
+      - name: Test with pytest
+        run: |
+          pytest fire_mcp/tests -v

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 **/**/*.pyc
 **/**/*pycache*
 /*venv
+fire_mcp/.venv
+fire_mcp/*.egg-info
 .vscode/
 .hypothesis/
 **/**/*.gz

--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ Please see the [contributing guidelines][contributing] and [guiding principles][
 ### Random FIRE Data Generator
 Included is a [random data generator][random-fire] which will generate data in line with the FIRE schema, but not necessarily realistic. (eg. You might get a loan with a balance of 10 but accrued interest of 1 million)
 
+### MCP Server
+An [MCP](https://modelcontextprotocol.io) server for mapping external data onto FIRE is available in [`fire_mcp/`][fire-mcp].
+
 ### Testing
 You can run tests locally via `./run_tests.sh` or view the CI test results in the [Actions tab][actions]
 
@@ -56,4 +59,5 @@ You can run tests locally via `./run_tests.sh` or view the CI test results in th
 [odi]:		http://opendata.institute/
 [odine]:	https://opendataincubator.eu/
 [random-fire]:      https://github.com/SuadeLabs/fire/blob/master/random_fire_generator.py
+[fire-mcp]:         https://github.com/SuadeLabs/fire/blob/master/fire_mcp/README.md
 [actions]:        https://github.com/SuadeLabs/fire/actions/workflows/ci-pipeline.yml

--- a/documentation/properties/type.md
+++ b/documentation/properties/type.md
@@ -1622,7 +1622,7 @@ The settlement value is based on the difference between the exchange rate specif
 
 A [**forward rate agreement**][fra] is an interest rate forward contract in which the rate to be paid or received on a specific obligation for a set period of time, beginning at some time in the future, is determined at contract initiation.
 
-[fra]: https://www.bis.org/statistics/glossary.htm?&selection=315&scope=Statistics&c=a&base=term
+[fra]: https://data.bis.org/help/glossary?item=Forward+rate+agreements
 
 ### variance_swap
 

--- a/fire_mcp/README.md
+++ b/fire_mcp/README.md
@@ -1,0 +1,64 @@
+# fire-mcp
+
+An [MCP](https://modelcontextprotocol.io) server that exposes the FIRE data standard so a data
+engineering team's own AI assistant can look up fields, validate draft records, and get mapping
+suggestions while mapping an internal data format onto FIRE.
+
+It reads `schemas/`, `extensions/`, `documentation/` and `examples/` directly from this repo
+checkout at runtime -- there's no build step and no network access, so pin it to a release tag
+(e.g. `git checkout v26.07`) if you want a specific version of the standard.
+
+## Install
+
+From inside a clone of this repo:
+
+```bash
+pip install -e fire_mcp/
+```
+
+For local development (running the MCP inspector, tests):
+
+```bash
+pip install -e "fire_mcp/[dev]"
+```
+
+## Run
+
+```bash
+fire-mcp
+# or
+python -m fire_mcp.server
+```
+
+This serves over stdio by default. Point an MCP client at it, for example a `mcp.json`/client
+config entry like:
+
+```json
+{
+  "mcpServers": {
+    "fire": {
+      "command": "fire-mcp",
+      "cwd": "/path/to/your/clone/of/fire"
+    }
+  }
+}
+```
+
+If the server is installed somewhere other than inside the FIRE checkout you want it to read,
+set `FIRE_REPO_ROOT` to point at the clone instead of relying on `cwd`.
+
+## What it exposes
+
+Resources:
+- `fire://schemas/{entity}` -- an entity's schema, with all `$ref`s resolved inline
+- `fire://properties/{field}` -- the markdown documentation for one field
+- `fire://examples/{name}` -- a worked example payload
+- `fire://extensions/{entity}` -- an entity's jurisdiction-specific extension fields, if any
+
+Tools:
+- `list_entities` -- every FIRE entity with a short description
+- `search_fields(query)` -- fuzzy search over field names, descriptions and enum values
+- `get_field(entity, field)` -- full detail on one field
+- `validate_record(entity, record)` -- validate a JSON record against a FIRE schema
+- `suggest_mapping(entity, source_fields)` -- ranked, non-authoritative mapping candidates for a
+  list of your own field names

--- a/fire_mcp/fire_mcp/__init__.py
+++ b/fire_mcp/fire_mcp/__init__.py
@@ -1,0 +1,1 @@
+"""MCP server exposing the FIRE data standard for schema mapping."""

--- a/fire_mcp/fire_mcp/catalog.py
+++ b/fire_mcp/fire_mcp/catalog.py
@@ -1,0 +1,104 @@
+"""Entity/field catalog built on top of the eagerly-resolved schemas."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from . import docs, loader, refs
+
+
+class UnknownEntityError(ValueError):
+    def __init__(self, entity: str):
+        super().__init__(
+            f"Unknown FIRE entity: {entity!r}. Use list_entities to see valid names."
+        )
+        self.entity = entity
+
+
+class UnknownFieldError(ValueError):
+    def __init__(self, entity: str, field_name: str):
+        super().__init__(f"Unknown field {field_name!r} on entity {entity!r}.")
+        self.entity = entity
+        self.field_name = field_name
+
+
+@dataclass
+class Entity:
+    name: str
+    title: str | None
+    description: str | None
+    has_extension: bool
+
+
+@dataclass
+class Field:
+    name: str
+    entity: str
+    type: str | None = None
+    format: str | None = None
+    enum: list[str] | None = None
+    monetary: bool = False
+    description: str | None = None
+    doc_excerpt: str | None = None
+    jurisdictions: list[str] | None = None
+
+
+_KNOWN_ENTITIES = set(loader.list_schema_names())
+
+
+def ensure_known_entity(entity: str) -> None:
+    if entity not in _KNOWN_ENTITIES:
+        raise UnknownEntityError(entity)
+
+
+def list_entities() -> list[Entity]:
+    extension_names = set(loader.list_extension_names())
+    entities = []
+    for name in sorted(_KNOWN_ENTITIES):
+        schema = loader.load_schema(name)
+        entities.append(
+            Entity(
+                name=name,
+                title=schema.get("title"),
+                description=schema.get("description"),
+                has_extension=name in extension_names,
+            )
+        )
+    return entities
+
+
+def _field_from_spec(name: str, entity: str, spec: dict, is_extension: bool) -> Field:
+    doc = docs.load_field_doc(name, extension=is_extension)
+    return Field(
+        name=name,
+        entity=entity,
+        type=spec.get("type"),
+        format=spec.get("format"),
+        enum=spec.get("enum"),
+        monetary=bool(spec.get("monetary", False)),
+        description=spec.get("description"),
+        doc_excerpt=doc.excerpt if doc else None,
+        jurisdictions=spec.get("jurisdictions"),
+    )
+
+
+def list_fields(entity: str, with_extension: bool = True) -> list[Field]:
+    ensure_known_entity(entity)
+    resolved = refs.resolve_entity_schema(entity, with_extension=with_extension)
+    extension = loader.load_extension_schema(entity) if with_extension else None
+    extension_field_names = set(extension.get("properties", {})) if extension else set()
+    return [
+        _field_from_spec(name, entity, spec, name in extension_field_names)
+        for name, spec in resolved.get("properties", {}).items()
+    ]
+
+
+def get_field(entity: str, field_name: str) -> Field:
+    ensure_known_entity(entity)
+    resolved = refs.resolve_entity_schema(entity, with_extension=True)
+    properties = resolved.get("properties", {})
+    if field_name not in properties:
+        raise UnknownFieldError(entity, field_name)
+    extension = loader.load_extension_schema(entity)
+    is_extension = bool(extension and field_name in extension.get("properties", {}))
+    return _field_from_spec(field_name, entity, properties[field_name], is_extension)

--- a/fire_mcp/fire_mcp/docs.py
+++ b/fire_mcp/fire_mcp/docs.py
@@ -1,0 +1,40 @@
+"""Lookup and light parsing of documentation/properties/*.md files."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from . import loader
+
+_FRONT_MATTER_RE = re.compile(r"^---\n.*?\n---\n", re.DOTALL)
+
+
+@dataclass
+class Doc:
+    field: str
+    excerpt: str
+    full: str
+
+
+def _strip_front_matter(text: str) -> str:
+    return _FRONT_MATTER_RE.sub("", text, count=1).strip()
+
+
+def _first_paragraph(text: str) -> str:
+    for paragraph in text.split("\n\n"):
+        paragraph = paragraph.strip()
+        if not paragraph or paragraph.startswith("#") or set(paragraph) <= {"-"}:
+            continue
+        return paragraph
+    return ""
+
+
+def load_field_doc(field: str, extension: bool = False) -> Doc | None:
+    raw = loader.load_extension_doc(field) if extension else loader.load_doc(field)
+    if raw is None and extension:
+        raw = loader.load_doc(field)
+    if raw is None:
+        return None
+    body = _strip_front_matter(raw)
+    return Doc(field=field, excerpt=_first_paragraph(body), full=body)

--- a/fire_mcp/fire_mcp/loader.py
+++ b/fire_mcp/fire_mcp/loader.py
@@ -1,0 +1,68 @@
+"""Thin, cached file-IO over the FIRE repo's schemas/extensions/docs/examples.
+
+Every function here takes a bare name (no file extension) and returns parsed
+content, or None/raises FileNotFoundError depending on whether the caller can
+sensibly expect the file to be missing (extensions and docs are optional;
+base schemas and examples are not).
+"""
+
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from pathlib import Path
+
+from . import repo
+
+
+def _load_json(path: Path) -> dict:
+    with path.open(encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+@lru_cache(maxsize=None)
+def load_schema(entity: str) -> dict:
+    return _load_json(repo.SCHEMAS_DIR / f"{entity}.json")
+
+
+@lru_cache(maxsize=None)
+def load_extension_schema(entity: str) -> dict | None:
+    path = repo.EXTENSION_SCHEMAS_DIR / f"{entity}.json"
+    if not path.exists():
+        return None
+    return _load_json(path)
+
+
+@lru_cache(maxsize=None)
+def load_doc(field: str) -> str | None:
+    path = repo.DOCS_DIR / f"{field}.md"
+    if not path.exists():
+        return None
+    return path.read_text(encoding="utf-8")
+
+
+@lru_cache(maxsize=None)
+def load_extension_doc(field: str) -> str | None:
+    path = repo.EXTENSION_DOCS_DIR / f"{field}.md"
+    if not path.exists():
+        return None
+    return path.read_text(encoding="utf-8")
+
+
+@lru_cache(maxsize=None)
+def load_example(name: str) -> dict:
+    return _load_json(repo.EXAMPLES_DIR / f"{name}.json")
+
+
+def list_schema_names() -> list[str]:
+    # common.json holds shared field definitions referenced via $ref by the
+    # other schemas; it isn't itself an entity (no properties/title/records).
+    return sorted(p.stem for p in repo.SCHEMAS_DIR.glob("*.json") if p.stem != "common")
+
+
+def list_extension_names() -> list[str]:
+    return sorted(p.stem for p in repo.EXTENSION_SCHEMAS_DIR.glob("*.json"))
+
+
+def list_example_names() -> list[str]:
+    return sorted(p.stem for p in repo.EXAMPLES_DIR.glob("*.json"))

--- a/fire_mcp/fire_mcp/refs.py
+++ b/fire_mcp/fire_mcp/refs.py
@@ -1,0 +1,135 @@
+"""Local resolution of FIRE's `$ref`s.
+
+Every `$ref` in this repo points at
+``https://raw.githubusercontent.com/SuadeLabs/fire/<ref>/schemas/<file>.json``,
+optionally with a JSON-pointer fragment (a bare key into common.json, a
+``#/properties/<name>`` reference into another entity's schema, or an empty
+fragment used by extension files to pull in the whole base schema via
+``allOf``). There is never more than one hop of indirection and no ``$id`` is
+declared anywhere, so a small, purpose-built resolver is enough here -- a
+general JSON Schema resolver is not needed.
+
+Two resolution strategies live in this module:
+
+* :func:`build_resolver` hands jsonschema its own lazy resolver (via a
+  ``handlers`` callback that reads local files instead of the network) for
+  use during validation, where jsonschema's built-in fragment handling should
+  do the work.
+* :func:`resolve_entity_schema` / :func:`resolve_extension_only` eagerly walk
+  a schema and replace every ``$ref`` with its resolved value, producing a
+  self-contained schema with no ``$ref`` left -- used for the `fire://schemas`
+  resource, `get_field`, and the search index.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+import jsonschema
+
+from . import loader
+
+_FIRE_URL_RE = re.compile(
+    r"^https://raw\.githubusercontent\.com/SuadeLabs/fire/[^/]+/schemas/(?P<file>[\w.]+)\.json$"
+)
+
+
+class RefResolutionError(ValueError):
+    pass
+
+
+def _match_ref_url(url: str) -> str:
+    match = _FIRE_URL_RE.match(url)
+    if not match:
+        raise RefResolutionError(f"Unrecognised FIRE $ref: {url!r}")
+    return match.group("file")
+
+
+# --- Lazy resolution, for jsonschema validation --------------------------
+
+
+def _remote_handler(uri: str) -> dict:
+    """jsonschema RefResolver handler for the https:// scheme.
+
+    jsonschema strips any fragment before calling this (see
+    ``RefResolver.resolve_from_url``), so `uri` is always a bare schema URL
+    here; jsonschema resolves the fragment itself afterwards via
+    ``resolve_fragment``, which already does the right thing for both
+    common.json's flat keys and ``#/properties/<name>`` pointers.
+    """
+    entity = _match_ref_url(uri)
+    return loader.load_schema(entity)
+
+
+def build_resolver(schema: dict) -> jsonschema.RefResolver:
+    # TODO: jsonschema.RefResolver is soft-deprecated in favour of the
+    # `referencing` library (still works as of 4.25.1, via a back-compat
+    # shim, but emits a DeprecationWarning). Revisit once the mcp SDK's
+    # jsonschema floor and our own needs make a `referencing.Registry`
+    # based rewrite worthwhile.
+    return jsonschema.RefResolver(
+        base_uri="", referrer=schema, handlers={"https": _remote_handler}
+    )
+
+
+# --- Eager resolution, for presentation/search ----------------------------
+
+
+def _resolve_pointer(document: Any, fragment: str) -> Any:
+    node = document
+    for part in (p for p in fragment.split("/") if p):
+        node = node[part]
+    return node
+
+
+def _load_ref_target(ref: str) -> Any:
+    url, _, fragment = ref.partition("#")
+    entity = _match_ref_url(url)
+    return _resolve_pointer(loader.load_schema(entity), fragment)
+
+
+def _inline_resolve(node: Any) -> Any:
+    if isinstance(node, dict):
+        if "$ref" in node:
+            resolved = _inline_resolve(_load_ref_target(node["$ref"]))
+            extra = {k: v for k, v in node.items() if k != "$ref"}
+            if extra and isinstance(resolved, dict):
+                # A handful of extension properties attach a $ref alongside
+                # their own "description"/"jurisdictions" -- those sibling
+                # keys should win over whatever the referenced fragment says.
+                return {**resolved, **extra}
+            return resolved
+        return {key: _inline_resolve(value) for key, value in node.items()}
+    if isinstance(node, list):
+        return [_inline_resolve(value) for value in node]
+    return node
+
+
+def resolve_entity_schema(entity: str, with_extension: bool = False) -> dict:
+    base = loader.load_schema(entity)
+    result: dict[str, Any] = {
+        "title": base.get("title"),
+        "description": base.get("description"),
+        "type": base.get("type", "object"),
+        "required": base.get("required", []),
+        "properties": _inline_resolve(base.get("properties", {})),
+    }
+    if with_extension:
+        extension = loader.load_extension_schema(entity)
+        if extension is not None:
+            ext_properties = _inline_resolve(extension.get("properties", {}))
+            result["properties"] = {**result["properties"], **ext_properties}
+            result["extended"] = True
+    return result
+
+
+def resolve_extension_only(entity: str) -> dict | None:
+    extension = loader.load_extension_schema(entity)
+    if extension is None:
+        return None
+    return {
+        "title": extension.get("title"),
+        "description": extension.get("description"),
+        "properties": _inline_resolve(extension.get("properties", {})),
+    }

--- a/fire_mcp/fire_mcp/repo.py
+++ b/fire_mcp/fire_mcp/repo.py
@@ -1,0 +1,42 @@
+"""Locates the FIRE repo on disk so the rest of the package can read schemas,
+extensions, documentation and examples without ever making a network call."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def _looks_like_fire_repo(path: Path) -> bool:
+    return (path / "schemas").is_dir() and (path / "documentation").is_dir()
+
+
+def _find_repo_root() -> Path:
+    override = os.environ.get("FIRE_REPO_ROOT")
+    if override:
+        path = Path(override).expanduser().resolve()
+        if not _looks_like_fire_repo(path):
+            raise RuntimeError(
+                f"FIRE_REPO_ROOT={path} does not look like a FIRE repo "
+                "(expected schemas/ and documentation/ subdirectories)."
+            )
+        return path
+
+    here = Path(__file__).resolve()
+    for candidate in (here, *here.parents):
+        if _looks_like_fire_repo(candidate):
+            return candidate
+
+    raise RuntimeError(
+        "Could not locate the FIRE repo root. Run fire-mcp from inside a "
+        "clone of the FIRE repo, or set the FIRE_REPO_ROOT environment "
+        "variable to point at one."
+    )
+
+
+REPO_ROOT = _find_repo_root()
+SCHEMAS_DIR = REPO_ROOT / "schemas"
+EXTENSION_SCHEMAS_DIR = REPO_ROOT / "extensions" / "schemas"
+DOCS_DIR = REPO_ROOT / "documentation" / "properties"
+EXTENSION_DOCS_DIR = REPO_ROOT / "extensions" / "documentation" / "properties"
+EXAMPLES_DIR = REPO_ROOT / "examples"

--- a/fire_mcp/fire_mcp/resources.py
+++ b/fire_mcp/fire_mcp/resources.py
@@ -1,0 +1,45 @@
+"""Registers the fire:// resource URIs against an MCPServer instance."""
+
+from __future__ import annotations
+
+import json
+
+from mcp.server import MCPServer
+
+from . import catalog, docs, loader, refs
+
+
+def register(mcp: MCPServer) -> None:
+    @mcp.resource("fire://schemas/{entity}")
+    def schema_resource(entity: str) -> str:
+        """The FIRE schema for one entity, with all $refs resolved inline."""
+        catalog.ensure_known_entity(entity)
+        return json.dumps(
+            refs.resolve_entity_schema(entity, with_extension=False), indent=2
+        )
+
+    @mcp.resource("fire://extensions/{entity}")
+    def extension_resource(entity: str) -> str:
+        """The jurisdiction-specific extension fields for one entity, if any."""
+        catalog.ensure_known_entity(entity)
+        resolved = refs.resolve_extension_only(entity)
+        if resolved is None:
+            raise ValueError(f"No extension schema exists for entity {entity!r}.")
+        return json.dumps(resolved, indent=2)
+
+    @mcp.resource("fire://properties/{field}")
+    def property_resource(field: str) -> str:
+        """The markdown documentation for one FIRE field."""
+        doc = docs.load_field_doc(field)
+        if doc is None:
+            raise ValueError(f"No documentation found for field {field!r}.")
+        return doc.full
+
+    @mcp.resource("fire://examples/{name}")
+    def example_resource(name: str) -> str:
+        """A worked example FIRE payload, as stored in examples/."""
+        try:
+            example = loader.load_example(name)
+        except FileNotFoundError as exc:
+            raise ValueError(f"No example named {name!r}.") from exc
+        return json.dumps(example, indent=2)

--- a/fire_mcp/fire_mcp/search.py
+++ b/fire_mcp/fire_mcp/search.py
@@ -1,0 +1,130 @@
+"""Fuzzy search over FIRE fields, for `search_fields` and `suggest_mapping`.
+
+FIRE field names are abbreviated snake_case (`cust_id`, `mtm_dirty`,
+`acc_fv_change_before_taxes`), so token-based fuzzy scoring (rapidfuzz) does
+much better here than a plain character-diff ratio.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from rapidfuzz import fuzz, process
+
+from . import catalog, loader, refs
+
+_INDEX_CACHE: list[tuple[str, str, dict]] | None = None
+
+
+def _build_index() -> list[tuple[str, str, dict]]:
+    entries = []
+    for entity in loader.list_schema_names():
+        resolved = refs.resolve_entity_schema(entity, with_extension=True)
+        for field_name, spec in resolved.get("properties", {}).items():
+            entries.append((entity, field_name, spec))
+    return entries
+
+
+def _get_index() -> list[tuple[str, str, dict]]:
+    global _INDEX_CACHE
+    if _INDEX_CACHE is None:
+        _INDEX_CACHE = _build_index()
+    return _INDEX_CACHE
+
+
+@dataclass
+class SearchResult:
+    entity: str
+    field: str
+    score: float
+    matched_on: str
+    type: str | None
+    enum: list[str] | None
+    description: str | None
+
+
+def _candidate_texts(field_name: str, spec: dict) -> list[tuple[str, str]]:
+    texts = [("name", field_name)]
+    description = spec.get("description")
+    if description:
+        texts.append(("description", description))
+    for value in spec.get("enum") or []:
+        texts.append(("enum", value))
+    return texts
+
+
+# A single short enum value can score deceptively high against a longer
+# query under plain WRatio (e.g. the enum value "customer" scores higher
+# against "customer id" than the field "customer_id" does). Down-weight
+# enum/description matches slightly so a genuine field-name match wins ties.
+_CHANNEL_WEIGHT = {"name": 1.0, "description": 0.92, "enum": 0.85}
+
+
+def search_fields(query: str, limit: int = 10) -> list[SearchResult]:
+    scored = []
+    for entity, field_name, spec in _get_index():
+        best_score = 0.0
+        best_on = "name"
+        for kind, text in _candidate_texts(field_name, spec):
+            score = fuzz.WRatio(query, text) * _CHANNEL_WEIGHT[kind]
+            if score > best_score:
+                best_score, best_on = score, kind
+        scored.append((best_score, entity, field_name, spec, best_on))
+    scored.sort(key=lambda row: row[0], reverse=True)
+
+    results = []
+    for score, entity, field_name, spec, matched_on in scored[:limit]:
+        results.append(
+            SearchResult(
+                entity=entity,
+                field=field_name,
+                score=round(score, 1),
+                matched_on=matched_on,
+                type=spec.get("type"),
+                enum=spec.get("enum"),
+                description=spec.get("description"),
+            )
+        )
+    return results
+
+
+@dataclass
+class MappingCandidate:
+    source_field: str
+    entity_field: str
+    score: float
+    reason: str
+
+
+def suggest_mapping(
+    entity: str,
+    source_fields: list[str],
+    sample_values: dict[str, Any] | None = None,
+    limit_per_field: int = 3,
+) -> list[MappingCandidate]:
+    catalog.ensure_known_entity(entity)
+    resolved = refs.resolve_entity_schema(entity, with_extension=True)
+    properties = resolved.get("properties", {})
+    field_names = list(properties.keys())
+    sample_values = sample_values or {}
+
+    results = []
+    for source in source_fields:
+        matches = process.extract(
+            source, field_names, scorer=fuzz.token_set_ratio, limit=limit_per_field
+        )
+        sample = sample_values.get(source)
+        for candidate_name, score, _ in matches:
+            enum = properties[candidate_name].get("enum")
+            is_enum_match = sample is not None and enum and str(sample) in enum
+            adjusted = min(100.0, score + 15) if is_enum_match else score
+            results.append(
+                MappingCandidate(
+                    source_field=source,
+                    entity_field=candidate_name,
+                    score=round(adjusted, 1),
+                    reason="enum value match" if is_enum_match else "name similarity",
+                )
+            )
+    return results

--- a/fire_mcp/fire_mcp/server.py
+++ b/fire_mcp/fire_mcp/server.py
@@ -1,0 +1,19 @@
+"""Entry point: wires up the FIRE MCPServer and runs it (stdio by default)."""
+
+from __future__ import annotations
+
+from mcp.server import MCPServer
+
+from . import resources, tools
+
+mcp = MCPServer("fire")
+resources.register(mcp)
+tools.register(mcp)
+
+
+def main() -> None:
+    mcp.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/fire_mcp/fire_mcp/tools.py
+++ b/fire_mcp/fire_mcp/tools.py
@@ -1,0 +1,54 @@
+"""Registers the FIRE mapping-assistant tools against an MCPServer instance."""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from typing import Any
+
+from mcp.server import MCPServer
+
+from . import catalog, search, validation
+
+
+def register(mcp: MCPServer) -> None:
+    @mcp.tool()
+    def list_entities() -> list[dict[str, Any]]:
+        """List all FIRE entities (top-level schemas) with a short description."""
+        return [asdict(entity) for entity in catalog.list_entities()]
+
+    @mcp.tool()
+    def search_fields(query: str, limit: int = 10) -> list[dict[str, Any]]:
+        """Search FIRE field names, descriptions and enum values for a query string."""
+        return [asdict(result) for result in search.search_fields(query, limit=limit)]
+
+    @mcp.tool()
+    def get_field(entity: str, field: str) -> dict[str, Any]:
+        """Get full detail (type, format, enum, monetary flag, description, doc) for one FIRE field."""
+        return asdict(catalog.get_field(entity, field))
+
+    @mcp.tool()
+    def validate_record(
+        entity: str, record: dict[str, Any], jurisdiction: str | None = None
+    ) -> list[dict[str, Any]]:
+        """Validate a JSON record against a FIRE entity schema.
+
+        Returns a list of validation issues (empty if the record is valid).
+        """
+        issues = validation.validate_record(entity, record, jurisdiction=jurisdiction)
+        return [asdict(issue) for issue in issues]
+
+    @mcp.tool()
+    def suggest_mapping(
+        entity: str,
+        source_fields: list[str],
+        sample_values: dict[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
+        """Suggest FIRE field mappings for a list of internal/source field names.
+
+        Ranked, non-authoritative candidates -- a starting point for a mapping
+        table, not a substitute for review.
+        """
+        candidates = search.suggest_mapping(
+            entity, source_fields, sample_values=sample_values
+        )
+        return [asdict(candidate) for candidate in candidates]

--- a/fire_mcp/fire_mcp/validation.py
+++ b/fire_mcp/fire_mcp/validation.py
@@ -1,0 +1,67 @@
+"""Validate a record against a FIRE entity schema, without any network access."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import jsonschema
+import jsonschema.exceptions
+
+from . import catalog, loader, refs
+
+
+@dataclass
+class ValidationIssue:
+    path: str
+    message: str
+    kind: str
+    expected: Any = None
+    got: Any = None
+
+
+def _issue_kind(error: jsonschema.exceptions.ValidationError) -> str:
+    if error.validator == "required":
+        return "missing_required"
+    if error.validator == "type":
+        return "type_mismatch"
+    if error.validator == "enum":
+        return "enum_mismatch"
+    return "other"
+
+
+def _schema_for(entity: str, jurisdiction: str | None) -> dict:
+    schema = loader.load_schema(entity)
+    if jurisdiction is None:
+        return schema
+    extension = loader.load_extension_schema(entity)
+    if extension is None:
+        return schema
+    merged_properties = dict(schema.get("properties", {}))
+    for name, spec in extension.get("properties", {}).items():
+        if jurisdiction in (spec.get("jurisdictions") or []):
+            merged_properties[name] = spec
+    return {**schema, "properties": merged_properties}
+
+
+def validate_record(
+    entity: str, record: dict, jurisdiction: str | None = None
+) -> list[ValidationIssue]:
+    catalog.ensure_known_entity(entity)
+    schema = _schema_for(entity, jurisdiction)
+    resolver = refs.build_resolver(schema)
+    validator = jsonschema.Draft7Validator(schema, resolver=resolver)
+
+    issues = []
+    for error in validator.iter_errors(record):
+        path = "/".join(str(part) for part in error.absolute_path) or "<root>"
+        issues.append(
+            ValidationIssue(
+                path=path,
+                message=error.message,
+                kind=_issue_kind(error),
+                expected=error.validator_value,
+                got=error.instance,
+            )
+        )
+    return issues

--- a/fire_mcp/pyproject.toml
+++ b/fire_mcp/pyproject.toml
@@ -1,0 +1,23 @@
+[project]
+name = "fire-mcp"
+version = "0.1.0"
+description = "MCP server exposing the FIRE data standard for schema mapping"
+requires-python = ">=3.10"
+dependencies = [
+    "mcp==2.2.0",
+    "jsonschema>=4.20,<5",
+    "rapidfuzz>=3.6",
+]
+
+[project.optional-dependencies]
+dev = ["pytest>=7.0.0", "mcp[cli]==2.2.0"]
+
+[project.scripts]
+fire-mcp = "fire_mcp.server:main"
+
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+include = ["fire_mcp*"]

--- a/fire_mcp/tests/conftest.py
+++ b/fire_mcp/tests/conftest.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import socket
+
+import pytest
+
+
+@pytest.fixture
+def no_network(monkeypatch):
+    """Fail loudly if anything under test tries to open a real socket."""
+
+    def _blocked(*args, **kwargs):
+        raise AssertionError("network access attempted during offline ref resolution")
+
+    monkeypatch.setattr(socket, "socket", _blocked)
+    monkeypatch.setattr(socket, "create_connection", _blocked)

--- a/fire_mcp/tests/test_catalog.py
+++ b/fire_mcp/tests/test_catalog.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import pytest
+
+from fire_mcp import catalog, loader
+
+
+def test_list_entities_covers_all_schema_files():
+    entities = catalog.list_entities()
+    names = {entity.name for entity in entities}
+    assert names == set(loader.list_schema_names())
+    assert all(entity.description for entity in entities)
+
+
+def test_get_field_returns_expected_detail():
+    field = catalog.get_field("loan", "accrued_interest_balance")
+    assert field.type == "integer"
+    assert field.monetary is True
+    assert field.doc_excerpt
+    assert "accrued interest" in field.doc_excerpt.lower()
+
+
+def test_get_field_unknown_entity_raises():
+    with pytest.raises(catalog.UnknownEntityError):
+        catalog.get_field("not_a_real_entity", "id")
+
+
+def test_get_field_unknown_field_raises():
+    with pytest.raises(catalog.UnknownFieldError):
+        catalog.get_field("loan", "not_a_real_field")
+
+
+def test_get_field_extension_field_carries_jurisdictions():
+    field = catalog.get_field("loan", "anchor_tenant")
+    assert field.jurisdictions == ["US"]

--- a/fire_mcp/tests/test_mapping.py
+++ b/fire_mcp/tests/test_mapping.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from fire_mcp import search
+
+
+def test_suggest_mapping_finds_plausible_candidates():
+    results = search.suggest_mapping("loan", ["cust_id", "loan_bal", "orig_date"])
+    by_source: dict[str, list] = {}
+    for result in results:
+        by_source.setdefault(result.source_field, []).append(result)
+
+    assert set(by_source) == {"cust_id", "loan_bal", "orig_date"}
+    for source, candidates in by_source.items():
+        assert candidates, source
+        assert candidates[0].score > 0
+
+
+def test_suggest_mapping_boosts_enum_value_match():
+    results = search.suggest_mapping(
+        "loan",
+        ["accounting_basis"],
+        sample_values={"accounting_basis": "held_for_trading"},
+    )
+    matches = [r for r in results if r.entity_field == "accounting_treatment"]
+    assert matches
+    assert any(r.reason == "enum value match" for r in matches)

--- a/fire_mcp/tests/test_refs.py
+++ b/fire_mcp/tests/test_refs.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import pytest
+
+from fire_mcp import loader, refs
+
+
+def test_resolves_common_json_leaf_ref():
+    resolved = refs.resolve_entity_schema("loan")
+    accounting_treatment = resolved["properties"]["accounting_treatment"]
+    expected = loader.load_schema("common")["accounting_treatment"]
+    assert "$ref" not in accounting_treatment
+    assert accounting_treatment["enum"] == expected["enum"]
+
+
+def test_resolves_cross_entity_property_ref_with_sibling_overrides():
+    resolved = refs.resolve_extension_only("collateral")
+    orig = resolved["properties"]["orig_valuation_type"]
+    base_valuation_type = loader.load_schema("collateral")["properties"][
+        "valuation_type"
+    ]
+
+    assert "$ref" not in orig
+    # Sibling keys on the extension property win over the referenced fragment's own.
+    assert orig["description"] == "The value type at origination."
+    assert orig["jurisdictions"] == ["US"]
+    # Type/enum still come through from the referenced base property.
+    assert orig["type"] == base_valuation_type["type"]
+    assert orig["enum"] == base_valuation_type["enum"]
+
+
+def _has_ref(node) -> bool:
+    if isinstance(node, dict):
+        return "$ref" in node or any(_has_ref(v) for v in node.values())
+    if isinstance(node, list):
+        return any(_has_ref(v) for v in node)
+    return False
+
+
+def test_extension_composition_merges_base_and_extension_fields():
+    resolved = refs.resolve_entity_schema("loan", with_extension=True)
+    properties = resolved["properties"]
+
+    assert "accrual_status" in properties  # base-only field
+    assert "anchor_tenant" in properties  # US-extension-only field
+    assert resolved["extended"] is True
+    assert not _has_ref(properties)
+
+
+def test_unrecognised_ref_raises_without_network(no_network):
+    with pytest.raises(refs.RefResolutionError):
+        refs._load_ref_target("https://example.com/not-fire/schemas/loan.json#/x")
+
+
+def test_no_network_access_during_resolution_and_validation(no_network):
+    from fire_mcp import validation
+
+    refs.resolve_entity_schema("loan", with_extension=True)
+    validation.validate_record("loan", {"id": "x", "date": "2020-01-01T00:00:00Z"})

--- a/fire_mcp/tests/test_search.py
+++ b/fire_mcp/tests/test_search.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from fire_mcp import search
+
+
+def test_search_fields_typo_still_finds_target():
+    results = search.search_fields("acc_fv_chnge_credit_risk")
+    fields = {r.field for r in results}
+    assert "acc_fv_change_credit_risk" in fields
+
+
+def test_search_fields_matches_on_enum_value():
+    results = search.search_fields("fv_thru_pnl")
+    assert any(
+        r.field == "accounting_treatment" and r.matched_on == "enum" for r in results
+    )
+
+
+def test_search_fields_short_id_query_ranks_id_fields_first():
+    results = search.search_fields("customer id", limit=5)
+    assert results
+    assert results[0].field in {"id", "customer_id"}

--- a/fire_mcp/tests/test_validation.py
+++ b/fire_mcp/tests/test_validation.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import copy
+
+from fire_mcp import loader, validation
+
+CASES = [
+    ("bond_future", "derivative"),
+    ("current_account_with_guarantee", "account"),
+]
+
+
+def _records(example_name: str, entity: str) -> list[dict]:
+    example = loader.load_example(example_name)
+    return example["data"][entity]
+
+
+def test_examples_validate_cleanly():
+    for example_name, entity in CASES:
+        for record in _records(example_name, entity):
+            issues = validation.validate_record(entity, record)
+            assert issues == [], f"{example_name}/{entity}: {issues}"
+
+
+def test_missing_required_field_detected():
+    example_name, entity = CASES[0]
+    record = copy.deepcopy(_records(example_name, entity)[0])
+    del record["id"]
+    issues = validation.validate_record(entity, record)
+    assert any(issue.kind == "missing_required" for issue in issues)
+
+
+def test_wrong_type_detected():
+    example_name, entity = CASES[0]
+    record = copy.deepcopy(_records(example_name, entity)[0])
+    record["notional_amount"] = "not-a-number"
+    issues = validation.validate_record(entity, record)
+    assert any(issue.kind == "type_mismatch" for issue in issues)
+
+
+def test_bad_enum_detected():
+    example_name, entity = CASES[0]
+    record = copy.deepcopy(_records(example_name, entity)[0])
+    record["asset_class"] = "not_a_real_asset_class"
+    issues = validation.validate_record(entity, record)
+    assert any(issue.kind == "enum_mismatch" for issue in issues)


### PR DESCRIPTION
## Summary
- Adds `fire_mcp/`, an MCP server exposing FIRE's schemas, extensions, documentation and examples as resources and tools (`list_entities`, `search_fields`, `get_field`, `validate_record`, `suggest_mapping`) so data engineering teams can query the standard interactively while mapping their own formats onto it.
- Resolves all `$ref`s locally (schemas/, extensions/schemas/, common.json) with no network access at runtime, unlike the existing test-only ref walker in `tests/__init__.py`.
- Ships as its own installable package (`fire_mcp/pyproject.toml`) with its own test suite, run against a clone of this repo.
- Updates CI to scope the existing test job to `tests/` and adds a dedicated job for `fire_mcp`'s own suite.

## Test plan
- [x] `fire_mcp/tests` passes (19 tests) in a dedicated virtualenv
- [x] Root `tests/` suite still passes unaffected (529 passed, 2 skipped)
- [x] `ruff check` and `black --check` pass on the new code
- [x] End-to-end smoke test through the running `MCPServer` instance: listed tools/resource templates, called all 5 tools and read all 4 resource types