### PR TITLE
fix: replace dead BIS glossary link for forward rate agreements

### DIFF
--- a/documentation/properties/type.md
+++ b/documentation/properties/type.md
@@ -1622,7 +1622,7 @@ The settlement value is based on the difference between the exchange rate specif
 
 A [**forward rate agreement**][fra] is an interest rate forward contract in which the rate to be paid or received on a specific obligation for a set period of time, beginning at some time in the future, is determined at contract initiation.
 
-[fra]: https://www.bis.org/statistics/glossary.htm?&selection=315&scope=Statistics&c=a&base=term
+[fra]: https://data.bis.org/help/glossary?item=Forward+rate+agreements
 
 ### variance_swap
 


### PR DESCRIPTION
## Summary
- The `fra` glossary link in `documentation/properties/type.md` pointed at `https://www.bis.org/statistics/glossary.htm?...`, which now 404s.
- Replaced with the current equivalent entry on `data.bis.org`.

Found while running `tests/test_docs.py::TestDocs::test_urls_in_docs` on an unrelated branch -- this is an independent fix, not tied to anything else in flight.

## Test plan
- [x] `pytest tests/test_docs.py -q` passes locally
- [x] New URL returns HTTP 200